### PR TITLE
feat: Add plan comparison page

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -53,6 +53,7 @@ import Dashboard from "./pages/careers/dashboard/index";
 
 import Pricing from "@/pages/pricing/Pricing";
 import ProductPricing from "@/pages/pricing/ProductPricing";
+import PlanComparison from "@/pages/pricing/PlanComparison";
 
 const queryClient = new QueryClient();
 
@@ -118,6 +119,10 @@ const App = () => {
               <Route
                 path="/pricing/:productSlug"
                 element={<ProductPricing />}
+              />
+              <Route
+                path="/pricing/:productSlug/compare"
+                element={<PlanComparison />}
               />
 
               {/* Blog */}

--- a/client/pages/pricing/PlanComparison.tsx
+++ b/client/pages/pricing/PlanComparison.tsx
@@ -1,0 +1,450 @@
+import { useParams, useNavigate } from "react-router-dom";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { useState } from "react";
+
+const products = [
+  { slug: "mylapay-tokenx", name: "TokenX", fullName: "Mylapay TokenX" },
+  { slug: "mylapay-secure", name: "Secure", fullName: "Mylapay Secure" },
+  { slug: "mylapay-cswitch", name: "C-Switch", fullName: "Mylapay C-Switch" },
+  {
+    slug: "mylapay-intellewatch",
+    name: "IntelleWatch",
+    fullName: "IntelleWatch",
+  },
+  {
+    slug: "mylapay-intellesettle",
+    name: "IntelleSettle",
+    fullName: "IntelleSettle",
+  },
+  {
+    slug: "mylapay-intellesolve",
+    name: "IntelleSolve",
+    fullName: "IntelleSolve",
+  },
+  { slug: "mylapay-intelle360", name: "Intelle360", fullName: "Intelle360" },
+  { slug: "mylapay-uswitch", name: "U-Switch", fullName: "Mylapay U-Switch" },
+  { slug: "mylapay-intellepro", name: "IntellePro", fullName: "IntellePro" },
+  { slug: "mylapay-switchx", name: "SwitchX", fullName: "Mylapay SwitchX" },
+];
+
+const faqs = [
+  {
+    id: 1,
+    question: "Can I choose my meals?",
+    answer:
+      "Quisque rutrum. Aenean imperdi. Etiam ultricies nisi vel augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus, tellus eget.",
+    isOpen: false,
+  },
+  {
+    id: 2,
+    question: "When will I receive my order?",
+    answer: "",
+    isOpen: false,
+  },
+  {
+    id: 3,
+    question: "Can I skip a delivery?",
+    answer: "",
+    isOpen: false,
+  },
+  {
+    id: 4,
+    question: "Block title",
+    answer: "",
+    isOpen: false,
+  },
+];
+
+export default function PlanComparison() {
+  const { productSlug } = useParams<{ productSlug: string }>();
+  const navigate = useNavigate();
+  const [expandedFaq, setExpandedFaq] = useState<number | null>(1);
+  const [billingCycle, setBillingCycle] = useState<"yearly" | "monthly">(
+    "yearly",
+  );
+
+  const product = products.find((p) => p.slug === productSlug);
+
+  if (!product) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold mb-4">Product not found</h1>
+          <button
+            onClick={() => navigate("/pricing")}
+            className="text-blue-600 hover:underline"
+          >
+            Go back to pricing
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const toggleFaq = (id: number) => {
+    setExpandedFaq(expandedFaq === id ? null : id);
+  };
+
+  return (
+    <div className="min-h-screen bg-white">
+      {/* Header Section */}
+      <div className="w-full bg-white pt-20 pb-8 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-7xl mx-auto">
+          {/* Page Title */}
+          <div className="text-center mb-6">
+            <h1 className="text-3xl md:text-4xl font-bold mb-3">
+              <span className="text-blue-900">Choose Your </span>
+              <span className="text-[#2CADE3]">Plans</span>
+            </h1>
+            <p className="text-gray-800 text-base">With our Products</p>
+          </div>
+
+          {/* Product Selection */}
+          <div className="flex justify-center mb-8">
+            <div className="bg-[#1E3A8A] rounded-lg px-6 py-4">
+              <span className="text-white font-semibold text-xl md:text-2xl">
+                {product.fullName}
+              </span>
+            </div>
+          </div>
+
+          {/* Sub-header with Back Button and Feature Table Title */}
+          <div className="flex flex-col lg:flex-row items-start lg:items-center justify-between gap-6 mb-8 px-4 lg:px-10">
+            <button
+              onClick={() => navigate(`/pricing/${productSlug}`)}
+              className="flex items-center gap-2 px-4 py-2 border border-black rounded-lg hover:bg-gray-50 transition-colors"
+            >
+              <svg
+                className="w-3 h-6"
+                viewBox="0 0 12 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  fillRule="evenodd"
+                  clipRule="evenodd"
+                  d="M1.84306 11.2889L7.50006 5.63186L8.91406 7.04586L3.96406 11.9959L8.91406 16.9459L7.50006 18.3599L1.84306 12.7029C1.65559 12.5153 1.55028 12.261 1.55028 11.9959C1.55028 11.7307 1.65559 11.4764 1.84306 11.2889Z"
+                  fill="black"
+                />
+              </svg>
+              <span className="text-black font-semibold">Back to products</span>
+            </button>
+
+            <div className="flex-1 max-w-xl">
+              <h2 className="text-2xl md:text-3xl font-bold text-gray-900 mb-2">
+                Feature Table
+              </h2>
+              <p className="text-gray-900 text-base md:text-lg">
+                Choose the perfect plan for your business needs
+              </p>
+            </div>
+
+            <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3 ml-auto">
+              <div className="text-right whitespace-nowrap">
+                <span className="text-xs font-bold mr-2">Save 15%</span>
+                <span className="text-xs text-gray-600">on yearly plan!</span>
+              </div>
+              <div className="flex items-center gap-1 p-1 border border-gray-200 rounded-full bg-white">
+                <button
+                  onClick={() => setBillingCycle("yearly")}
+                  className={`px-4 py-2 rounded-full text-sm font-semibold transition-all ${
+                    billingCycle === "yearly"
+                      ? "bg-blue-900 text-white"
+                      : "text-gray-800"
+                  }`}
+                >
+                  Yearly
+                </button>
+                <button
+                  onClick={() => setBillingCycle("monthly")}
+                  className={`px-4 py-2 rounded-full text-sm font-semibold transition-all ${
+                    billingCycle === "monthly"
+                      ? "bg-blue-900 text-white"
+                      : "text-gray-800"
+                  }`}
+                >
+                  Monthly
+                </button>
+              </div>
+            </div>
+          </div>
+
+          {/* Plan Cards Section */}
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-0 border border-[#E6E9F5] mb-12">
+            {/* Compare Plans Column */}
+            <div className="bg-white p-6 md:p-8 border-b md:border-b-0 md:border-r border-[#E6E9F5] flex flex-col justify-between">
+              <div>
+                <h3 className="text-xl md:text-2xl font-bold text-gray-900 mb-4">
+                  Compare plans
+                </h3>
+                <div className="inline-flex items-center justify-center px-5 py-2 rounded-full border border-gray-400 mb-4">
+                  <span className="text-gray-900 font-medium">40% Off</span>
+                </div>
+                <p className="text-sm text-gray-500">
+                  Choose your workspace plan according to your organisational
+                  plan
+                </p>
+              </div>
+            </div>
+
+            {/* Trial Plan */}
+            <div className="bg-white p-6 md:p-7 border-b md:border-b-0 md:border-r border-[#E6E9F5] flex flex-col justify-between text-center">
+              <div>
+                <h3 className="text-3xl md:text-4xl font-bold text-gray-900 mb-1">
+                  Trial
+                </h3>
+                <p className="text-sm text-gray-500 mb-6">/Free (7 days)</p>
+              </div>
+              <button className="w-full bg-[#2CADE3] text-white py-3 md:py-4 text-sm font-bold rounded hover:bg-[#2399c9] transition-colors">
+                Try now
+              </button>
+            </div>
+
+            {/* $25 Plan */}
+            <div className="bg-white p-6 md:p-7 border-b md:border-b-0 md:border-r border-[#E6E9F5] flex flex-col justify-between text-center">
+              <div>
+                <h3 className="text-3xl md:text-4xl font-bold text-gray-900 mb-1">
+                  $25
+                </h3>
+                <p className="text-sm text-gray-500 mb-6">/Month</p>
+              </div>
+              <button className="w-full bg-[#2CADE3] text-white py-3 md:py-4 text-sm font-bold rounded hover:bg-[#2399c9] transition-colors">
+                Choose This Plan
+              </button>
+            </div>
+
+            {/* $40 Plan */}
+            <div className="bg-white p-6 md:p-7 border-b md:border-b-0 md:border-r border-[#E6E9F5] flex flex-col justify-between text-center">
+              <div>
+                <h3 className="text-3xl md:text-4xl font-bold text-gray-900 mb-1">
+                  $40
+                </h3>
+                <p className="text-sm text-gray-500 mb-6">/Month</p>
+              </div>
+              <button className="w-full bg-[#2CADE3] text-white py-3 md:py-4 text-sm font-bold rounded hover:bg-[#2399c9] transition-colors">
+                Choose This Plan
+              </button>
+            </div>
+
+            {/* Custom Plan */}
+            <div className="bg-white p-6 md:p-7 border-b md:border-b-0 border-[#E6E9F5] flex flex-col justify-between text-center">
+              <div>
+                <h3 className="text-3xl md:text-4xl font-bold text-gray-900 mb-6">
+                  Custom
+                </h3>
+              </div>
+              <button className="w-full bg-[#2CADE3] text-white py-3 md:py-4 text-sm font-bold rounded hover:bg-[#2399c9] transition-colors">
+                Contact Now
+              </button>
+            </div>
+          </div>
+
+          {/* Feature Comparison Table */}
+          <div className="border border-[#E6E9F5] mb-12">
+            <div className="grid grid-cols-1 md:grid-cols-5">
+              {/* Feature Names Column */}
+              <div className="bg-white border-r border-[#E6E9F5]">
+                {[
+                  "Daily Throughput",
+                  "Monthly Transaction Quota",
+                  "Overage Charges",
+                  "Deployment",
+                  "Value-Added Services (VAS)",
+                  "Support",
+                  "Best For",
+                ].map((feature, idx) => (
+                  <div
+                    key={idx}
+                    className="p-5 border-b border-[#E6E9F5] h-20 flex items-center"
+                  >
+                    <span className="text-gray-900 font-medium text-base md:text-lg">
+                      {feature}
+                    </span>
+                  </div>
+                ))}
+              </div>
+
+              {/* Trial Column */}
+              <div className="bg-white border-r border-[#E6E9F5]">
+                {[
+                  "100 trans/day",
+                  <CloseIcon key="close1" />,
+                  <CloseIcon key="close2" />,
+                  <CloseIcon key="close3" />,
+                  <CloseIcon key="close4" />,
+                  "Email",
+                  "Evaluation & Testing",
+                ].map((value, idx) => (
+                  <div
+                    key={idx}
+                    className="p-5 border-b border-[#E6E9F5] h-20 flex items-center justify-center"
+                  >
+                    {typeof value === "string" ? (
+                      <span className="text-gray-900 font-medium text-center">
+                        {value}
+                      </span>
+                    ) : (
+                      value
+                    )}
+                  </div>
+                ))}
+              </div>
+
+              {/* $25 Column */}
+              <div className="bg-white border-r border-[#E6E9F5]">
+                {[
+                  "500 trans/day",
+                  "limited",
+                  "Per-transaction",
+                  <CloseIcon key="close5" />,
+                  <CloseIcon key="close6" />,
+                  "Standard Support",
+                  "Small Businesses",
+                ].map((value, idx) => (
+                  <div
+                    key={idx}
+                    className="p-5 border-b border-[#E6E9F5] h-20 flex items-center justify-center"
+                  >
+                    {typeof value === "string" ? (
+                      <span
+                        className={`text-gray-900 font-medium text-center ${idx === 1 ? "font-semibold" : ""}`}
+                      >
+                        {value}
+                      </span>
+                    ) : (
+                      value
+                    )}
+                  </div>
+                ))}
+              </div>
+
+              {/* $40 Column */}
+              <div className="bg-white border-r border-[#E6E9F5]">
+                {[
+                  "1,000+ trans/day",
+                  "Standard",
+                  "Reduced rate",
+                  <CloseIcon key="close7" />,
+                  <CheckIcon key="check1" />,
+                  "Priority Support",
+                  "Growing Merchants",
+                ].map((value, idx) => (
+                  <div
+                    key={idx}
+                    className="p-5 border-b border-[#E6E9F5] h-20 flex items-center justify-center"
+                  >
+                    {typeof value === "string" ? (
+                      <span
+                        className={`text-gray-900 font-medium text-center ${idx === 1 ? "font-semibold" : ""}`}
+                      >
+                        {value}
+                      </span>
+                    ) : (
+                      value
+                    )}
+                  </div>
+                ))}
+              </div>
+
+              {/* Custom Column */}
+              <div className="bg-white">
+                {[
+                  "5,000+ trans/day",
+                  "High",
+                  "Volume-based",
+                  "Client-side Deployment",
+                  <CheckIcon key="check2" />,
+                  "24×7 Dedicated Support",
+                  "High-Volume Enterprises",
+                ].map((value, idx) => (
+                  <div
+                    key={idx}
+                    className="p-5 border-b border-[#E6E9F5] h-20 flex items-center justify-center"
+                  >
+                    {typeof value === "string" ? (
+                      <span
+                        className={`text-gray-900 font-medium text-center ${idx === 1 ? "font-semibold" : ""}`}
+                      >
+                        {value}
+                      </span>
+                    ) : (
+                      value
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* FAQ Section */}
+          <div className="max-w-4xl mx-auto py-12">
+            <h2 className="text-3xl md:text-4xl font-bold text-[#1E3A8A] text-center mb-8">
+              Frequently Asked Question
+            </h2>
+
+            <div className="space-y-3">
+              {faqs.map((faq) => (
+                <div
+                  key={faq.id}
+                  className="bg-white rounded-lg border border-gray-100"
+                >
+                  <button
+                    onClick={() => toggleFaq(faq.id)}
+                    className="w-full flex items-center justify-between p-4 md:p-6 text-left hover:bg-gray-50 transition-colors"
+                  >
+                    <h3 className="text-lg md:text-2xl font-bold text-gray-900 pr-4">
+                      {faq.question}
+                    </h3>
+                    {expandedFaq === faq.id ? (
+                      <ChevronDown className="w-4 h-4 text-[#2CADE3] flex-shrink-0" />
+                    ) : (
+                      <ChevronRight className="w-4 h-4 text-[#2CADE3] flex-shrink-0" />
+                    )}
+                  </button>
+
+                  {expandedFaq === faq.id && faq.answer && (
+                    <div className="px-4 md:px-6 pb-4 md:pb-6">
+                      <p className="text-gray-600 text-base md:text-lg leading-relaxed">
+                        {faq.answer}
+                      </p>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const CloseIcon = () => (
+  <svg
+    className="w-5 h-5"
+    viewBox="0 0 20 20"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M10 1.25C5.125 1.25 1.25 5.125 1.25 10C1.25 14.875 5.125 18.75 10 18.75C14.875 18.75 18.75 14.875 18.75 10C18.75 5.125 14.875 1.25 10 1.25ZM13.375 14.375L10 11L6.625 14.375L5.625 13.375L9 10L5.625 6.625L6.625 5.625L10 9L13.375 5.625L14.375 6.625L11 10L14.375 13.375L13.375 14.375Z"
+      fill="black"
+    />
+  </svg>
+);
+
+const CheckIcon = () => (
+  <svg
+    className="w-5 h-5"
+    viewBox="0 0 20 20"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M11.6125 1.36104C10.6812 0.574966 9.3188 0.574967 8.38749 1.36104L7.53932 2.07692C7.14349 2.41102 6.65365 2.61394 6.1375 2.65759L5.03155 2.75111C3.81717 2.85381 2.85381 3.81717 2.75111 5.03155L2.65759 6.1375C2.61394 6.65365 2.41102 7.14349 2.07692 7.53934L1.36104 8.38749C0.574966 9.3188 0.574967 10.6812 1.36104 11.6125L2.07692 12.4607C2.41102 12.8565 2.61394 13.3464 2.65759 13.8625L2.75111 14.9685C2.85381 16.1829 3.81717 17.1462 5.03155 17.2489L6.1375 17.3424C6.65365 17.3861 7.14349 17.589 7.53934 17.9231L8.38749 18.639C9.3188 19.425 10.6812 19.425 11.6125 18.639L12.4607 17.9231C12.8565 17.589 13.3464 17.3861 13.8625 17.3424L14.9685 17.2489C16.1829 17.1462 17.1462 16.1829 17.2489 14.9685L17.3424 13.8625C17.3861 13.3464 17.589 12.8565 17.9231 12.4607L18.639 11.6125C19.425 10.6812 19.425 9.3188 18.639 8.38749L17.9231 7.53932C17.589 7.14349 17.3861 6.65365 17.3424 6.1375L17.2489 5.03155C17.1462 3.81717 16.1829 2.85381 14.9685 2.75111L13.8625 2.65759C13.3464 2.61394 12.8565 2.41102 12.4607 2.07692L11.6125 1.36104ZM14.546 8.29555C14.9854 7.85621 14.9854 7.1439 14.546 6.70456C14.1067 6.26521 13.3944 6.26521 12.955 6.70456L8.75054 10.9091L7.04604 9.20456C6.6067 8.76521 5.89439 8.76521 5.45505 9.20456C5.0157 9.6439 5.0157 10.3562 5.45505 10.7956L7.95505 13.2955C8.39439 13.7349 9.1067 13.7349 9.54604 13.2955L14.546 8.29555Z"
+      fill="#252430"
+    />
+  </svg>
+);

--- a/client/pages/pricing/PlanComparison.tsx
+++ b/client/pages/pricing/PlanComparison.tsx
@@ -92,17 +92,17 @@ export default function PlanComparison() {
         <div className="max-w-7xl mx-auto">
           {/* Page Title */}
           <div className="text-center mb-6">
-            <h1 className="text-2xl md:text-3xl font-bold mb-3">
+            <h1 className="text-xl md:text-2xl font-bold mb-3">
               <span className="text-blue-900">Choose Your </span>
               <span className="text-[#2CADE3]">Plans</span>
             </h1>
-            <p className="text-gray-800 text-sm">With our Products</p>
+            <p className="text-gray-800 text-xs">With our Products</p>
           </div>
 
           {/* Product Selection */}
           <div className="flex justify-center mb-8">
             <div className="bg-[#1E3A8A] rounded-lg px-6 py-4">
-              <span className="text-white font-semibold text-lg md:text-xl">
+              <span className="text-white font-semibold text-base md:text-lg">
                 {product.fullName}
               </span>
             </div>
@@ -131,10 +131,10 @@ export default function PlanComparison() {
             </button>
 
             <div className="flex-1 max-w-xl">
-              <h2 className="text-xl md:text-2xl font-bold text-gray-900 mb-2">
+              <h2 className="text-lg md:text-xl font-bold text-gray-900 mb-2">
                 Feature Table
               </h2>
-              <p className="text-gray-900 text-sm md:text-base">
+              <p className="text-gray-900 text-xs md:text-sm">
                 Choose the perfect plan for your business needs
               </p>
             </div>
@@ -147,7 +147,7 @@ export default function PlanComparison() {
               <div className="flex items-center gap-1 p-1 border border-gray-200 rounded-full bg-white">
                 <button
                   onClick={() => setBillingCycle("yearly")}
-                  className={`px-3 py-1 rounded-full text-xs font-semibold transition-all ${
+                  className={`px-3 py-1 rounded-full text-[11px] font-semibold transition-all ${
                     billingCycle === "yearly"
                       ? "bg-blue-900 text-white"
                       : "text-gray-800"
@@ -157,7 +157,7 @@ export default function PlanComparison() {
                 </button>
                 <button
                   onClick={() => setBillingCycle("monthly")}
-                  className={`px-3 py-1 rounded-full text-xs font-semibold transition-all ${
+                  className={`px-3 py-1 rounded-full text-[11px] font-semibold transition-all ${
                     billingCycle === "monthly"
                       ? "bg-blue-900 text-white"
                       : "text-gray-800"
@@ -174,7 +174,7 @@ export default function PlanComparison() {
             {/* Compare Plans Column */}
             <div className="bg-white p-6 md:p-8 border-b md:border-b-0 md:border-r border-[#E6E9F5] flex flex-col justify-between">
               <div>
-                <h3 className="text-lg md:text-xl font-bold text-gray-900 mb-4">
+                <h3 className="text-base md:text-lg font-bold text-gray-900 mb-4">
                   Compare plans
                 </h3>
                 <div className="inline-flex items-center justify-center px-5 py-2 rounded-full border border-gray-400 mb-4">
@@ -190,7 +190,7 @@ export default function PlanComparison() {
             {/* Trial Plan */}
             <div className="bg-white p-6 md:p-7 border-b md:border-b-0 md:border-r border-[#E6E9F5] flex flex-col justify-between text-center">
               <div>
-                <h3 className="text-2xl md:text-3xl font-bold text-gray-900 mb-1">
+                <h3 className="text-xl md:text-2xl font-bold text-gray-900 mb-1">
                   Trial
                 </h3>
                 <p className="text-xs text-gray-500 mb-6">/Free (7 days)</p>
@@ -203,7 +203,7 @@ export default function PlanComparison() {
             {/* $25 Plan */}
             <div className="bg-white p-6 md:p-7 border-b md:border-b-0 md:border-r border-[#E6E9F5] flex flex-col justify-between text-center">
               <div>
-                <h3 className="text-2xl md:text-3xl font-bold text-gray-900 mb-1">
+                <h3 className="text-xl md:text-2xl font-bold text-gray-900 mb-1">
                   $25
                 </h3>
                 <p className="text-xs text-gray-500 mb-6">/Month</p>
@@ -216,7 +216,7 @@ export default function PlanComparison() {
             {/* $40 Plan */}
             <div className="bg-white p-6 md:p-7 border-b md:border-b-0 md:border-r border-[#E6E9F5] flex flex-col justify-between text-center">
               <div>
-                <h3 className="text-2xl md:text-3xl font-bold text-gray-900 mb-1">
+                <h3 className="text-xl md:text-2xl font-bold text-gray-900 mb-1">
                   $40
                 </h3>
                 <p className="text-xs text-gray-500 mb-6">/Month</p>
@@ -229,7 +229,7 @@ export default function PlanComparison() {
             {/* Custom Plan */}
             <div className="bg-white p-6 md:p-7 border-b md:border-b-0 border-[#E6E9F5] flex flex-col justify-between text-center">
               <div>
-                <h3 className="text-3xl md:text-4xl font-bold text-gray-900 mb-6">
+                <h3 className="text-xl md:text-2xl font-bold text-gray-900 mb-6">
                   Custom
                 </h3>
               </div>
@@ -255,9 +255,9 @@ export default function PlanComparison() {
                 ].map((feature, idx) => (
                   <div
                     key={idx}
-                    className="p-5 border-b border-[#E6E9F5] h-20 flex items-center"
+                    className="p-3 border-b border-[#E6E9F5] h-16 flex items-center"
                   >
-                    <span className="text-gray-900 font-medium text-sm md:text-base">
+                    <span className="text-gray-900 font-medium text-xs md:text-sm">
                       {feature}
                     </span>
                   </div>
@@ -277,7 +277,7 @@ export default function PlanComparison() {
                 ].map((value, idx) => (
                   <div
                     key={idx}
-                    className="p-5 border-b border-[#E6E9F5] h-20 flex items-center justify-center"
+                    className="p-3 border-b border-[#E6E9F5] h-16 flex items-center justify-center"
                   >
                     {typeof value === "string" ? (
                       <span className="text-gray-900 font-medium text-sm text-center">
@@ -303,7 +303,7 @@ export default function PlanComparison() {
                 ].map((value, idx) => (
                   <div
                     key={idx}
-                    className="p-5 border-b border-[#E6E9F5] h-20 flex items-center justify-center"
+                    className="p-3 border-b border-[#E6E9F5] h-16 flex items-center justify-center"
                   >
                     {typeof value === "string" ? (
                       <span
@@ -331,7 +331,7 @@ export default function PlanComparison() {
                 ].map((value, idx) => (
                   <div
                     key={idx}
-                    className="p-5 border-b border-[#E6E9F5] h-20 flex items-center justify-center"
+                    className="p-3 border-b border-[#E6E9F5] h-16 flex items-center justify-center"
                   >
                     {typeof value === "string" ? (
                       <span
@@ -359,7 +359,7 @@ export default function PlanComparison() {
                 ].map((value, idx) => (
                   <div
                     key={idx}
-                    className="p-5 border-b border-[#E6E9F5] h-20 flex items-center justify-center"
+                    className="p-3 border-b border-[#E6E9F5] h-16 flex items-center justify-center"
                   >
                     {typeof value === "string" ? (
                       <span
@@ -378,7 +378,7 @@ export default function PlanComparison() {
 
           {/* FAQ Section */}
           <div className="max-w-4xl mx-auto py-12">
-            <h2 className="text-2xl md:text-3xl font-bold text-[#1E3A8A] text-center mb-8">
+            <h2 className="text-xl md:text-2xl font-bold text-[#1E3A8A] text-center mb-8">
               Frequently Asked Question
             </h2>
 
@@ -392,7 +392,7 @@ export default function PlanComparison() {
                     onClick={() => toggleFaq(faq.id)}
                     className="w-full flex items-center justify-between p-4 md:p-6 text-left hover:bg-gray-50 transition-colors"
                   >
-                    <h3 className="text-base md:text-xl font-bold text-gray-900 pr-4">
+                    <h3 className="text-sm md:text-base font-bold text-gray-900 pr-4">
                       {faq.question}
                     </h3>
                     {expandedFaq === faq.id ? (

--- a/client/pages/pricing/PlanComparison.tsx
+++ b/client/pages/pricing/PlanComparison.tsx
@@ -92,17 +92,17 @@ export default function PlanComparison() {
         <div className="max-w-7xl mx-auto">
           {/* Page Title */}
           <div className="text-center mb-6">
-            <h1 className="text-3xl md:text-4xl font-bold mb-3">
+            <h1 className="text-2xl md:text-3xl font-bold mb-3">
               <span className="text-blue-900">Choose Your </span>
               <span className="text-[#2CADE3]">Plans</span>
             </h1>
-            <p className="text-gray-800 text-base">With our Products</p>
+            <p className="text-gray-800 text-sm">With our Products</p>
           </div>
 
           {/* Product Selection */}
           <div className="flex justify-center mb-8">
             <div className="bg-[#1E3A8A] rounded-lg px-6 py-4">
-              <span className="text-white font-semibold text-xl md:text-2xl">
+              <span className="text-white font-semibold text-lg md:text-xl">
                 {product.fullName}
               </span>
             </div>
@@ -131,10 +131,10 @@ export default function PlanComparison() {
             </button>
 
             <div className="flex-1 max-w-xl">
-              <h2 className="text-2xl md:text-3xl font-bold text-gray-900 mb-2">
+              <h2 className="text-xl md:text-2xl font-bold text-gray-900 mb-2">
                 Feature Table
               </h2>
-              <p className="text-gray-900 text-base md:text-lg">
+              <p className="text-gray-900 text-sm md:text-base">
                 Choose the perfect plan for your business needs
               </p>
             </div>
@@ -147,7 +147,7 @@ export default function PlanComparison() {
               <div className="flex items-center gap-1 p-1 border border-gray-200 rounded-full bg-white">
                 <button
                   onClick={() => setBillingCycle("yearly")}
-                  className={`px-4 py-2 rounded-full text-sm font-semibold transition-all ${
+                  className={`px-3 py-1 rounded-full text-xs font-semibold transition-all ${
                     billingCycle === "yearly"
                       ? "bg-blue-900 text-white"
                       : "text-gray-800"
@@ -157,7 +157,7 @@ export default function PlanComparison() {
                 </button>
                 <button
                   onClick={() => setBillingCycle("monthly")}
-                  className={`px-4 py-2 rounded-full text-sm font-semibold transition-all ${
+                  className={`px-3 py-1 rounded-full text-xs font-semibold transition-all ${
                     billingCycle === "monthly"
                       ? "bg-blue-900 text-white"
                       : "text-gray-800"
@@ -174,13 +174,13 @@ export default function PlanComparison() {
             {/* Compare Plans Column */}
             <div className="bg-white p-6 md:p-8 border-b md:border-b-0 md:border-r border-[#E6E9F5] flex flex-col justify-between">
               <div>
-                <h3 className="text-xl md:text-2xl font-bold text-gray-900 mb-4">
+                <h3 className="text-lg md:text-xl font-bold text-gray-900 mb-4">
                   Compare plans
                 </h3>
                 <div className="inline-flex items-center justify-center px-5 py-2 rounded-full border border-gray-400 mb-4">
                   <span className="text-gray-900 font-medium">40% Off</span>
                 </div>
-                <p className="text-sm text-gray-500">
+                <p className="text-xs text-gray-500">
                   Choose your workspace plan according to your organisational
                   plan
                 </p>
@@ -190,12 +190,12 @@ export default function PlanComparison() {
             {/* Trial Plan */}
             <div className="bg-white p-6 md:p-7 border-b md:border-b-0 md:border-r border-[#E6E9F5] flex flex-col justify-between text-center">
               <div>
-                <h3 className="text-3xl md:text-4xl font-bold text-gray-900 mb-1">
+                <h3 className="text-2xl md:text-3xl font-bold text-gray-900 mb-1">
                   Trial
                 </h3>
-                <p className="text-sm text-gray-500 mb-6">/Free (7 days)</p>
+                <p className="text-xs text-gray-500 mb-6">/Free (7 days)</p>
               </div>
-              <button className="w-full bg-[#2CADE3] text-white py-3 md:py-4 text-sm font-bold rounded hover:bg-[#2399c9] transition-colors">
+              <button className="w-full bg-[#2CADE3] text-white py-2 md:py-3 text-xs font-bold rounded hover:bg-[#2399c9] transition-colors">
                 Try now
               </button>
             </div>
@@ -203,12 +203,12 @@ export default function PlanComparison() {
             {/* $25 Plan */}
             <div className="bg-white p-6 md:p-7 border-b md:border-b-0 md:border-r border-[#E6E9F5] flex flex-col justify-between text-center">
               <div>
-                <h3 className="text-3xl md:text-4xl font-bold text-gray-900 mb-1">
+                <h3 className="text-2xl md:text-3xl font-bold text-gray-900 mb-1">
                   $25
                 </h3>
-                <p className="text-sm text-gray-500 mb-6">/Month</p>
+                <p className="text-xs text-gray-500 mb-6">/Month</p>
               </div>
-              <button className="w-full bg-[#2CADE3] text-white py-3 md:py-4 text-sm font-bold rounded hover:bg-[#2399c9] transition-colors">
+              <button className="w-full bg-[#2CADE3] text-white py-2 md:py-3 text-xs font-bold rounded hover:bg-[#2399c9] transition-colors">
                 Choose This Plan
               </button>
             </div>
@@ -216,12 +216,12 @@ export default function PlanComparison() {
             {/* $40 Plan */}
             <div className="bg-white p-6 md:p-7 border-b md:border-b-0 md:border-r border-[#E6E9F5] flex flex-col justify-between text-center">
               <div>
-                <h3 className="text-3xl md:text-4xl font-bold text-gray-900 mb-1">
+                <h3 className="text-2xl md:text-3xl font-bold text-gray-900 mb-1">
                   $40
                 </h3>
-                <p className="text-sm text-gray-500 mb-6">/Month</p>
+                <p className="text-xs text-gray-500 mb-6">/Month</p>
               </div>
-              <button className="w-full bg-[#2CADE3] text-white py-3 md:py-4 text-sm font-bold rounded hover:bg-[#2399c9] transition-colors">
+              <button className="w-full bg-[#2CADE3] text-white py-2 md:py-3 text-xs font-bold rounded hover:bg-[#2399c9] transition-colors">
                 Choose This Plan
               </button>
             </div>
@@ -233,7 +233,7 @@ export default function PlanComparison() {
                   Custom
                 </h3>
               </div>
-              <button className="w-full bg-[#2CADE3] text-white py-3 md:py-4 text-sm font-bold rounded hover:bg-[#2399c9] transition-colors">
+              <button className="w-full bg-[#2CADE3] text-white py-2 md:py-3 text-xs font-bold rounded hover:bg-[#2399c9] transition-colors">
                 Contact Now
               </button>
             </div>
@@ -257,7 +257,7 @@ export default function PlanComparison() {
                     key={idx}
                     className="p-5 border-b border-[#E6E9F5] h-20 flex items-center"
                   >
-                    <span className="text-gray-900 font-medium text-base md:text-lg">
+                    <span className="text-gray-900 font-medium text-sm md:text-base">
                       {feature}
                     </span>
                   </div>
@@ -280,7 +280,7 @@ export default function PlanComparison() {
                     className="p-5 border-b border-[#E6E9F5] h-20 flex items-center justify-center"
                   >
                     {typeof value === "string" ? (
-                      <span className="text-gray-900 font-medium text-center">
+                      <span className="text-gray-900 font-medium text-sm text-center">
                         {value}
                       </span>
                     ) : (
@@ -307,7 +307,7 @@ export default function PlanComparison() {
                   >
                     {typeof value === "string" ? (
                       <span
-                        className={`text-gray-900 font-medium text-center ${idx === 1 ? "font-semibold" : ""}`}
+                        className={`text-gray-900 font-medium text-sm text-center ${idx === 1 ? "font-semibold" : ""}`}
                       >
                         {value}
                       </span>
@@ -335,7 +335,7 @@ export default function PlanComparison() {
                   >
                     {typeof value === "string" ? (
                       <span
-                        className={`text-gray-900 font-medium text-center ${idx === 1 ? "font-semibold" : ""}`}
+                        className={`text-gray-900 font-medium text-sm text-center ${idx === 1 ? "font-semibold" : ""}`}
                       >
                         {value}
                       </span>
@@ -363,7 +363,7 @@ export default function PlanComparison() {
                   >
                     {typeof value === "string" ? (
                       <span
-                        className={`text-gray-900 font-medium text-center ${idx === 1 ? "font-semibold" : ""}`}
+                        className={`text-gray-900 font-medium text-sm text-center ${idx === 1 ? "font-semibold" : ""}`}
                       >
                         {value}
                       </span>
@@ -378,7 +378,7 @@ export default function PlanComparison() {
 
           {/* FAQ Section */}
           <div className="max-w-4xl mx-auto py-12">
-            <h2 className="text-3xl md:text-4xl font-bold text-[#1E3A8A] text-center mb-8">
+            <h2 className="text-2xl md:text-3xl font-bold text-[#1E3A8A] text-center mb-8">
               Frequently Asked Question
             </h2>
 
@@ -392,7 +392,7 @@ export default function PlanComparison() {
                     onClick={() => toggleFaq(faq.id)}
                     className="w-full flex items-center justify-between p-4 md:p-6 text-left hover:bg-gray-50 transition-colors"
                   >
-                    <h3 className="text-lg md:text-2xl font-bold text-gray-900 pr-4">
+                    <h3 className="text-base md:text-xl font-bold text-gray-900 pr-4">
                       {faq.question}
                     </h3>
                     {expandedFaq === faq.id ? (

--- a/client/pages/pricing/PlanComparison.tsx
+++ b/client/pages/pricing/PlanComparison.tsx
@@ -102,7 +102,7 @@ export default function PlanComparison() {
           {/* Product Selection */}
           <div className="flex justify-center mb-8">
             <div className="bg-[#1E3A8A] rounded-lg px-6 py-4">
-              <span className="text-white font-semibold text-base md:text-lg">
+              <span className="text-white font-semibold text-sm md:text-base">
                 {product.fullName}
               </span>
             </div>
@@ -170,14 +170,14 @@ export default function PlanComparison() {
           </div>
 
           {/* Plan Cards Section */}
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-0 border border-[#E6E9F5] mb-12">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-0 border border-[#E6E9F5] mb-6">
             {/* Compare Plans Column */}
-            <div className="bg-white p-6 md:p-8 border-b md:border-b-0 md:border-r border-[#E6E9F5] flex flex-col justify-between">
+            <div className="bg-white p-4 md:p-6 border-b md:border-b-0 md:border-r border-[#E6E9F5] flex flex-col justify-between">
               <div>
-                <h3 className="text-base md:text-lg font-bold text-gray-900 mb-4">
+                <h3 className="text-base md:text-lg font-bold text-gray-900 mb-2">
                   Compare plans
                 </h3>
-                <div className="inline-flex items-center justify-center px-5 py-2 rounded-full border border-gray-400 mb-4">
+                <div className="inline-flex items-center justify-center px-3 py-1 rounded-full border border-gray-400 mb-2">
                   <span className="text-gray-900 font-medium">40% Off</span>
                 </div>
                 <p className="text-xs text-gray-500">
@@ -240,7 +240,7 @@ export default function PlanComparison() {
           </div>
 
           {/* Feature Comparison Table */}
-          <div className="border border-[#E6E9F5] mb-12">
+          <div className="border border-[#E6E9F5] mb-6">
             <div className="grid grid-cols-1 md:grid-cols-5">
               {/* Feature Names Column */}
               <div className="bg-white border-r border-[#E6E9F5]">
@@ -255,7 +255,7 @@ export default function PlanComparison() {
                 ].map((feature, idx) => (
                   <div
                     key={idx}
-                    className="p-3 border-b border-[#E6E9F5] h-16 flex items-center"
+                    className="p-2 border-b border-[#E6E9F5] h-14 flex items-center"
                   >
                     <span className="text-gray-900 font-medium text-xs md:text-sm">
                       {feature}
@@ -277,7 +277,7 @@ export default function PlanComparison() {
                 ].map((value, idx) => (
                   <div
                     key={idx}
-                    className="p-3 border-b border-[#E6E9F5] h-16 flex items-center justify-center"
+                    className="p-2 border-b border-[#E6E9F5] h-14 flex items-center justify-center"
                   >
                     {typeof value === "string" ? (
                       <span className="text-gray-900 font-medium text-sm text-center">
@@ -303,7 +303,7 @@ export default function PlanComparison() {
                 ].map((value, idx) => (
                   <div
                     key={idx}
-                    className="p-3 border-b border-[#E6E9F5] h-16 flex items-center justify-center"
+                    className="p-2 border-b border-[#E6E9F5] h-14 flex items-center justify-center"
                   >
                     {typeof value === "string" ? (
                       <span
@@ -331,7 +331,7 @@ export default function PlanComparison() {
                 ].map((value, idx) => (
                   <div
                     key={idx}
-                    className="p-3 border-b border-[#E6E9F5] h-16 flex items-center justify-center"
+                    className="p-2 border-b border-[#E6E9F5] h-14 flex items-center justify-center"
                   >
                     {typeof value === "string" ? (
                       <span
@@ -359,7 +359,7 @@ export default function PlanComparison() {
                 ].map((value, idx) => (
                   <div
                     key={idx}
-                    className="p-3 border-b border-[#E6E9F5] h-16 flex items-center justify-center"
+                    className="p-2 border-b border-[#E6E9F5] h-14 flex items-center justify-center"
                   >
                     {typeof value === "string" ? (
                       <span

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -172,8 +172,20 @@ export default function ProductPricing() {
 
           let verifyData: any = null;
           try {
-            const txtv = await verifyRes.clone().text();
-            verifyData = txtv ? JSON.parse(txtv) : { ok: false, error: "Empty verify response" };
+            if (verifyRes.bodyUsed) {
+              verifyData = { ok: false, error: "Verify response body already used" };
+            } else {
+              try {
+                verifyData = await verifyRes.json();
+              } catch (jerr) {
+                try {
+                  const txtv = await verifyRes.text();
+                  verifyData = txtv ? JSON.parse(txtv) : { ok: false, error: "Empty verify response" };
+                } catch (terr) {
+                  verifyData = { ok: false, error: String(terr || jerr) };
+                }
+              }
+            }
           } catch (err) {
             verifyData = { ok: false, error: String(err) };
           }

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -159,7 +159,7 @@ export default function ProductPricing() {
 
           let verifyData: any = null;
           try {
-            const txtv = await verifyRes.text();
+            const txtv = await verifyRes.clone().text();
             verifyData = txtv ? JSON.parse(txtv) : { ok: false, error: "Empty verify response" };
           } catch (err) {
             verifyData = { ok: false, error: String(err) };

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -1,6 +1,12 @@
 import { useParams, useNavigate } from "react-router-dom";
-import { Check } from "lucide-react";
+import { Check, X } from "lucide-react";
 import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogOverlay,
+  DialogPortal,
+} from "@/components/ui/dialog";
 
 const products = [
   { slug: "mylapay-tokenx", name: "TokenX", fullName: "Mylapay TokenX" },
@@ -33,6 +39,8 @@ export default function ProductPricing() {
   const [billingCycle, setBillingCycle] = useState<"yearly" | "monthly">(
     "yearly",
   );
+  const [showTrialModal, setShowTrialModal] = useState(false);
+  const [email, setEmail] = useState("");
 
   const product = products.find((p) => p.slug === productSlug);
 
@@ -121,7 +129,10 @@ export default function ProductPricing() {
                 </div>
               </div>
 
-              <button className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium transition-colors group-hover:bg-white group-hover:text-[#052343]">
+              <button
+                onClick={() => setShowTrialModal(true)}
+                className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium transition-colors group-hover:bg-white group-hover:text-[#052343]"
+              >
                 Try Now
               </button>
               <div className="flex justify-center mt-3">

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -92,9 +92,9 @@ export default function ProductPricing() {
         </div>
 
         {/* Pricing Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 items-stretch">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 items-end">
           {/* Trial Plan */}
-          <div className="relative overflow-hidden group bg-white rounded-2xl shadow-xl p-6 md:p-8 flex flex-col min-h-[12rem]">
+          <div className="relative overflow-hidden group bg-white rounded-2xl shadow-xl p-6 md:p-8 flex flex-col min-h-[14rem]">
             <div className="absolute inset-0 bg-gradient-to-b from-[#2CADE3] to-[#052343] opacity-0 transition-opacity duration-300 group-hover:opacity-100"></div>
 
             <div className="relative z-10 text-gray-900 group-hover:text-white">
@@ -132,7 +132,7 @@ export default function ProductPricing() {
           </div>
 
           {/* Basic Plan */}
-          <div className="relative overflow-hidden group bg-white rounded-2xl shadow-xl p-6 md:p-8 flex flex-col min-h-[18rem]">
+          <div className="relative overflow-hidden group bg-white rounded-2xl shadow-xl p-6 md:p-8 flex flex-col min-h-[22rem]">
             <div className="absolute inset-0 bg-gradient-to-b from-[#2CADE3] to-[#052343] opacity-0 transition-opacity duration-300 group-hover:opacity-100"></div>
 
             <div className="relative z-10 text-gray-900 group-hover:text-white">
@@ -177,7 +177,7 @@ export default function ProductPricing() {
           </div>
 
           {/* Pro Plan - Best Seller */}
-          <div className="relative overflow-hidden group bg-white rounded-2xl shadow-xl p-6 md:p-8 flex flex-col min-h-[26rem]">
+          <div className="relative overflow-hidden group bg-white rounded-2xl shadow-xl p-6 md:p-8 flex flex-col min-h-[28rem]">
             <div className="absolute top-2 right-2 bg-[#FFCD38] px-3 py-1 rounded text-xs font-medium z-20">
               Best Seller
             </div>
@@ -231,7 +231,7 @@ export default function ProductPricing() {
           </div>
 
           {/* Enterprise Plan */}
-          <div className="relative overflow-hidden group bg-white rounded-2xl shadow-xl p-6 md:p-8 flex flex-col min-h-[32rem]">
+          <div className="relative overflow-hidden group bg-white rounded-2xl shadow-xl p-6 md:p-8 flex flex-col min-h-[26rem]">
             <div className="absolute inset-0 bg-gradient-to-b from-[#2CADE3] to-[#052343] opacity-0 transition-opacity duration-300 group-hover:opacity-100"></div>
 
             <div className="relative z-10 text-gray-900 group-hover:text-white">

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -124,12 +124,14 @@ export default function ProductPricing() {
               <button className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium transition-colors group-hover:bg-white group-hover:text-[#052343]">
                 Try Now
               </button>
-              <button
-                onClick={() => navigate(`/pricing/${productSlug}/compare`)}
-                className="inline-block mt-2 text-xs text-gray-600 underline group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3] mx-auto"
-              >
-                See more
-              </button>
+              <div className="flex justify-center">
+                <button
+                  onClick={() => navigate(`/pricing/${productSlug}/compare`)}
+                  className="text-xs text-gray-600 underline group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3]"
+                >
+                  See more
+                </button>
+              </div>
             </div>
           </div>
 
@@ -169,12 +171,14 @@ export default function ProductPricing() {
               <button className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium transition-colors group-hover:bg-white group-hover:text-[#052343]">
                 Buy Now
               </button>
-              <button
-                onClick={() => navigate(`/pricing/${productSlug}/compare`)}
-                className="inline-block mt-2 text-xs text-gray-600 underline group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3] mx-auto"
-              >
-                See more
-              </button>
+              <div className="flex justify-center">
+                <button
+                  onClick={() => navigate(`/pricing/${productSlug}/compare`)}
+                  className="text-xs text-gray-600 underline group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3]"
+                >
+                  See more
+                </button>
+              </div>
             </div>
           </div>
 
@@ -223,12 +227,14 @@ export default function ProductPricing() {
               <button className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium transition-colors group-hover:bg-white group-hover:text-[#052343]">
                 Buy Now
               </button>
-              <button
-                onClick={() => navigate(`/pricing/${productSlug}/compare`)}
-                className="inline-block mt-2 text-xs text-gray-600 underline group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3] mx-auto"
-              >
-                See more
-              </button>
+              <div className="flex justify-center">
+                <button
+                  onClick={() => navigate(`/pricing/${productSlug}/compare`)}
+                  className="text-xs text-gray-600 underline group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3]"
+                >
+                  See more
+                </button>
+              </div>
             </div>
           </div>
 
@@ -280,12 +286,14 @@ export default function ProductPricing() {
               <button className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium transition-colors group-hover:bg-white group-hover:text-[#052343]">
                 Contact Now
               </button>
-              <button
-                onClick={() => navigate(`/pricing/${productSlug}/compare`)}
-                className="inline-block mt-2 text-xs text-gray-600 underline group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3] mx-auto"
-              >
-                See more
-              </button>
+              <div className="flex justify-center">
+                <button
+                  onClick={() => navigate(`/pricing/${productSlug}/compare`)}
+                  className="text-xs text-gray-600 underline group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3]"
+                >
+                  See more
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -126,7 +126,7 @@ export default function ProductPricing() {
               </button>
               <button
                 onClick={() => navigate(`/pricing/${productSlug}/compare`)}
-                className="text-center text-xs text-gray-600 underline mt-2 block group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3]"
+                className="inline-block mt-2 text-xs text-gray-600 underline group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3] mx-auto"
               >
                 See more
               </button>
@@ -171,7 +171,7 @@ export default function ProductPricing() {
               </button>
               <button
                 onClick={() => navigate(`/pricing/${productSlug}/compare`)}
-                className="text-center text-xs text-gray-600 underline mt-2 block group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3]"
+                className="inline-block mt-2 text-xs text-gray-600 underline group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3] mx-auto"
               >
                 See more
               </button>
@@ -225,7 +225,7 @@ export default function ProductPricing() {
               </button>
               <button
                 onClick={() => navigate(`/pricing/${productSlug}/compare`)}
-                className="text-center text-xs text-gray-600 underline mt-2 block group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3]"
+                className="inline-block mt-2 text-xs text-gray-600 underline group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3] mx-auto"
               >
                 See more
               </button>
@@ -282,7 +282,7 @@ export default function ProductPricing() {
               </button>
               <button
                 onClick={() => navigate(`/pricing/${productSlug}/compare`)}
-                className="text-center text-xs text-gray-600 underline mt-2 block group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3]"
+                className="inline-block mt-2 text-xs text-gray-600 underline group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3] mx-auto"
               >
                 See more
               </button>

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -120,27 +120,13 @@ export default function ProductPricing() {
         body: JSON.stringify({ amount, currency: "INR", receipt: `rcpt_${Date.now()}`, notes: { plan: checkoutPlan.key } }),
       });
 
+      // Read response text once and parse
       let data: any = null;
-      // Try safe parsing using clone() to avoid 'body stream already read'
       try {
-        try {
-          data = await resp.clone().json();
-        } catch (jsonErr) {
-          const txt = await resp.clone().text();
-          try {
-            data = txt ? JSON.parse(txt) : { ok: false, error: "Empty response" };
-          } catch (parseErr) {
-            data = { ok: false, error: String(parseErr), raw: txt };
-          }
-        }
+        const txt = await resp.text();
+        data = txt ? JSON.parse(txt) : { ok: false, error: "Empty response" };
       } catch (err) {
-        // As a last resort, attempt to read text from original response
-        try {
-          const txt = await resp.text();
-          data = txt ? JSON.parse(txt) : { ok: false, error: "Empty response" };
-        } catch (finalErr) {
-          data = { ok: false, error: String(finalErr) };
-        }
+        data = { ok: false, error: String(err) };
       }
 
       if (!data || !data.ok) throw new Error(data?.error || "Failed to create order");

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -6,6 +6,7 @@ import {
   DialogContent,
   DialogOverlay,
   DialogPortal,
+  DialogTitle,
 } from "@/components/ui/dialog";
 
 const products = [

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -126,7 +126,7 @@ export default function ProductPricing() {
                 Try Now
               </button>
               <button
-                onClick={() => navigateToCompare(`/pricing/${productSlug}/compare`)}
+                onClick={() => navigate(`/pricing/${productSlug}/compare`)}
                 className="text-center text-xs text-gray-600 underline mt-2 block group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3]"
               >
                 See more
@@ -171,7 +171,7 @@ export default function ProductPricing() {
                 Buy Now
               </button>
               <button
-                onClick={() => navigateToCompare(`/pricing/${productSlug}/compare`)}
+                onClick={() => navigate(`/pricing/${productSlug}/compare`)}
                 className="text-center text-xs text-gray-600 underline mt-2 block group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3]"
               >
                 See more
@@ -225,7 +225,7 @@ export default function ProductPricing() {
                 Buy Now
               </button>
               <button
-                onClick={() => navigateToCompare(`/pricing/${productSlug}/compare`)}
+                onClick={() => navigate(`/pricing/${productSlug}/compare`)}
                 className="text-center text-xs text-gray-600 underline mt-2 block group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3]"
               >
                 See more
@@ -282,7 +282,7 @@ export default function ProductPricing() {
                 Contact Now
               </button>
               <button
-                onClick={() => navigateToCompare(`/pricing/${productSlug}/compare`)}
+                onClick={() => navigate(`/pricing/${productSlug}/compare`)}
                 className="text-center text-xs text-gray-600 underline mt-2 block group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3]"
               >
                 See more

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -1,7 +1,6 @@
 import { useParams, useNavigate } from "react-router-dom";
 import { Check } from "lucide-react";
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
 
 const products = [
   { slug: "mylapay-tokenx", name: "TokenX", fullName: "Mylapay TokenX" },

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -314,34 +314,27 @@ export default function ProductPricing() {
       {/* Trial Signup Modal */}
       <Dialog open={showTrialModal} onOpenChange={setShowTrialModal}>
         <DialogPortal>
-          <DialogOverlay className="bg-black/60" />
-          <DialogContent className="max-w-lg sm:max-w-xl md:max-w-2xl p-0 gap-0 border-0 rounded-2xl shadow-2xl">
+          <DialogOverlay className="bg-white/30 backdrop-blur-sm" />
+          <DialogContent className="max-w-md p-4 sm:p-6 rounded-xl shadow-2xl">
             <DialogTitle className="sr-only">Join Our Trial on Token X</DialogTitle>
-            <button
-              onClick={() => setShowTrialModal(false)}
-              className="absolute right-6 top-6 z-10 rounded-sm opacity-70 hover:opacity-100 transition-opacity"
-              aria-label="Close"
-            >
-              <X className="h-8 w-8" />
-            </button>
 
-            <div className="p-8 md:p-12">
-              <div className="text-center mb-8">
-                <h2 className="text-3xl md:text-4xl font-bold text-[#1E3A8A] mb-2">
-                  Join Our Trail on
+            <div className="p-4 sm:p-6">
+              <div className="text-center mb-4">
+                <h2 className="text-xl md:text-2xl font-bold text-[#1E3A8A] mb-1">
+                  Join Our Trial on
                 </h2>
-                <h3 className="text-3xl md:text-4xl font-bold text-[#2CADE3]">
+                <h3 className="text-xl md:text-2xl font-bold text-[#2CADE3]">
                   Token X
                 </h3>
               </div>
 
-              <div className="space-y-4">
+              <div className="space-y-3">
                 <input
                   type="email"
                   placeholder="Email address"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
-                  className="w-full px-4 py-3 border border-black/50 rounded-md text-base placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#2CADE3] focus:border-transparent"
+                  className="w-full px-3 py-2 border border-black/30 rounded-md text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#2CADE3] focus:border-transparent"
                 />
 
                 <button
@@ -350,14 +343,14 @@ export default function ProductPricing() {
                     setShowTrialModal(false);
                     setEmail("");
                   }}
-                  className="w-full bg-[#2CADE3] text-white py-3 rounded-md text-base font-normal hover:bg-[#2399c9] transition-colors"
+                  className="w-full bg-[#2CADE3] text-white py-2 rounded-md text-sm font-medium hover:bg-[#2399c9] transition-colors"
                 >
                   Try now the trial
                 </button>
               </div>
 
-              <p className="text-center text-gray-500 text-sm mt-6">
-                Submit your email address to join the trail plan
+              <p className="text-center text-gray-500 text-xs mt-4">
+                Submit your email address to join the trial plan
               </p>
             </div>
           </DialogContent>

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -34,17 +34,38 @@ const products = [
   { slug: "mylapay-switchx", name: "SwitchX", fullName: "Mylapay SwitchX" },
 ];
 
-const planDetails: Record<string, { title: string; priceYearly: string; priceMonthly: string }> = {
-  trial: { title: "Trial", priceYearly: "Free (up to 7 days)", priceMonthly: "Free" },
-  basic: { title: "Basic Plan", priceYearly: "$499 / Year", priceMonthly: "$49 / Month" },
-  pro: { title: "Pro Plan", priceYearly: "$999 / Year", priceMonthly: "$99 / Month" },
-  enterprise: { title: "Enterprise Plan", priceYearly: "Contact for pricing", priceMonthly: "Contact for pricing" },
+const planDetails: Record<
+  string,
+  { title: string; priceYearly: string; priceMonthly: string }
+> = {
+  trial: {
+    title: "Trial",
+    priceYearly: "Free (up to 7 days)",
+    priceMonthly: "Free",
+  },
+  basic: {
+    title: "Basic Plan",
+    priceYearly: "$499 / Year",
+    priceMonthly: "$49 / Month",
+  },
+  pro: {
+    title: "Pro Plan",
+    priceYearly: "$999 / Year",
+    priceMonthly: "$99 / Month",
+  },
+  enterprise: {
+    title: "Enterprise Plan",
+    priceYearly: "Contact for pricing",
+    priceMonthly: "Contact for pricing",
+  },
 };
 
 export default function ProductPricing() {
   const { productSlug } = useParams<{ productSlug: string }>();
   const navigate = useNavigate();
-  const [billingCycle, setBillingCycle] = useState<"yearly" | "monthly">("yearly");
+  const [billingCycle, setBillingCycle] = useState<"yearly" | "monthly">(
+    "yearly",
+  );
 
   // Trial modal state
   const [showTrialModal, setShowTrialModal] = useState(false);
@@ -52,7 +73,11 @@ export default function ProductPricing() {
 
   // Checkout modal state
   const [showCheckoutModal, setShowCheckoutModal] = useState(false);
-  const [checkoutPlan, setCheckoutPlan] = useState<{ key: string; title: string; price: string } | null>(null);
+  const [checkoutPlan, setCheckoutPlan] = useState<{
+    key: string;
+    title: string;
+    price: string;
+  } | null>(null);
   const [checkoutEmail, setCheckoutEmail] = useState("");
   const [checkoutFirstName, setCheckoutFirstName] = useState("");
   const [checkoutLastName, setCheckoutLastName] = useState("");
@@ -64,7 +89,10 @@ export default function ProductPricing() {
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">
           <h1 className="text-2xl font-bold mb-4">Product not found</h1>
-          <button onClick={() => navigate("/pricing")} className="text-blue-600 hover:underline">
+          <button
+            onClick={() => navigate("/pricing")}
+            className="text-blue-600 hover:underline"
+          >
             Go back to pricing
           </button>
         </div>
@@ -74,7 +102,8 @@ export default function ProductPricing() {
 
   function openCheckoutFor(key: string) {
     const details = planDetails[key];
-    const price = billingCycle === "yearly" ? details.priceYearly : details.priceMonthly;
+    const price =
+      billingCycle === "yearly" ? details.priceYearly : details.priceMonthly;
     setCheckoutPlan({ key, title: details.title, price });
     setShowCheckoutModal(true);
   }
@@ -117,24 +146,38 @@ export default function ProductPricing() {
       const axios = (await import("axios")).default;
       // Handle zero/placeholder amounts: show message and abort
       if (!amount || amount <= 0) {
-        alert("This plan requires custom pricing or is free. Please contact sales.");
+        alert(
+          "This plan requires custom pricing or is free. Please contact sales.",
+        );
         setShowCheckoutModal(false);
         return;
       }
 
       let data: any;
       try {
-        const createResp = await axios.post("/api/razorpay/create-order", { amount, currency: "INR", receipt: `rcpt_${Date.now()}`, notes: { plan: checkoutPlan.key } });
+        const createResp = await axios.post("/api/razorpay/create-order", {
+          amount,
+          currency: "INR",
+          receipt: `rcpt_${Date.now()}`,
+          notes: { plan: checkoutPlan.key },
+        });
         data = createResp.data;
       } catch (err: any) {
         console.error("Create order axios error:", err?.response || err);
         const serverErr = err?.response?.data || err?.message || String(err);
-        alert("Payment initialization failed: " + (typeof serverErr === "string" ? serverErr : JSON.stringify(serverErr)));
+        alert(
+          "Payment initialization failed: " +
+            (typeof serverErr === "string"
+              ? serverErr
+              : JSON.stringify(serverErr)),
+        );
         return;
       }
 
       if (!data || !data.ok) {
-        alert("Failed to create order: " + (data?.error || JSON.stringify(data)));
+        alert(
+          "Failed to create order: " + (data?.error || JSON.stringify(data)),
+        );
         return;
       }
 
@@ -227,7 +270,9 @@ export default function ProductPricing() {
               <button
                 onClick={() => setBillingCycle("yearly")}
                 className={`px-3 py-1 rounded-full text-xs font-semibold transition-all ${
-                  billingCycle === "yearly" ? "bg-blue-900 text-white" : "text-gray-800"
+                  billingCycle === "yearly"
+                    ? "bg-blue-900 text-white"
+                    : "text-gray-800"
                 }`}
               >
                 Yearly
@@ -235,7 +280,9 @@ export default function ProductPricing() {
               <button
                 onClick={() => setBillingCycle("monthly")}
                 className={`px-3 py-1 rounded-full text-xs font-semibold transition-all ${
-                  billingCycle === "monthly" ? "bg-blue-900 text-white" : "text-gray-800"
+                  billingCycle === "monthly"
+                    ? "bg-blue-900 text-white"
+                    : "text-gray-800"
                 }`}
               >
                 Monthly
@@ -252,27 +299,43 @@ export default function ProductPricing() {
 
             <div className="relative z-10 text-gray-900 group-hover:text-white">
               <div className="text-center mb-6">
-                <h3 className="text-2xl font-semibold mb-2">{planDetails.trial.title}</h3>
-                <p className="text-[#2CADE3] text-lg mb-3 group-hover:text-white">{planDetails.trial.priceYearly}</p>
-                <p className="text-xs text-gray-600 group-hover:text-gray-100">Best for initial evaluation and integration testing</p>
+                <h3 className="text-2xl font-semibold mb-2">
+                  {planDetails.trial.title}
+                </h3>
+                <p className="text-[#2CADE3] text-lg mb-3 group-hover:text-white">
+                  {planDetails.trial.priceYearly}
+                </p>
+                <p className="text-xs text-gray-600 group-hover:text-gray-100">
+                  Best for initial evaluation and integration testing
+                </p>
               </div>
 
               <div className="space-y-3 mb-6 flex-grow">
                 <div className="flex items-start gap-2">
                   <Check className="w-5 h-5 text-gray-800 group-hover:text-white flex-shrink-0 mt-0.5" />
-                  <span className="text-xs text-gray-600 group-hover:text-gray-100">Upto 100 transactions per day</span>
+                  <span className="text-xs text-gray-600 group-hover:text-gray-100">
+                    Upto 100 transactions per day
+                  </span>
                 </div>
                 <div className="flex items-start gap-2">
                   <Check className="w-5 h-5 text-gray-800 group-hover:text-white flex-shrink-0 mt-0.5" />
-                  <span className="text-xs text-gray-600 group-hover:text-gray-100">Email support</span>
+                  <span className="text-xs text-gray-600 group-hover:text-gray-100">
+                    Email support
+                  </span>
                 </div>
               </div>
 
-              <button onClick={() => setShowTrialModal(true)} className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium transition-colors group-hover:bg-white group-hover:text-[#052343]">
+              <button
+                onClick={() => setShowTrialModal(true)}
+                className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium transition-colors group-hover:bg-white group-hover:text-[#052343]"
+              >
                 Try Now
               </button>
               <div className="flex justify-center mt-3">
-                <button onClick={() => navigate(`/pricing/${productSlug}/compare`)} className="text-xs text-gray-600 underline group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3]">
+                <button
+                  onClick={() => navigate(`/pricing/${productSlug}/compare`)}
+                  className="text-xs text-gray-600 underline group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3]"
+                >
                   See more
                 </button>
               </div>
@@ -285,31 +348,52 @@ export default function ProductPricing() {
 
             <div className="relative z-10 text-gray-900 group-hover:text-white">
               <div className="text-center mb-6">
-                <h3 className="text-2xl font-semibold mb-2">{planDetails.basic.title}</h3>
-                <p className="text-gray-600 text-lg mb-3 group-hover:text-white">{billingCycle === 'yearly' ? planDetails.basic.priceYearly : planDetails.basic.priceMonthly}</p>
-                <p className="text-xs text-gray-600 group-hover:text-gray-100">Ideal for small to mid-size merchants starting transaction processing</p>
+                <h3 className="text-2xl font-semibold mb-2">
+                  {planDetails.basic.title}
+                </h3>
+                <p className="text-gray-600 text-lg mb-3 group-hover:text-white">
+                  {billingCycle === "yearly"
+                    ? planDetails.basic.priceYearly
+                    : planDetails.basic.priceMonthly}
+                </p>
+                <p className="text-xs text-gray-600 group-hover:text-gray-100">
+                  Ideal for small to mid-size merchants starting transaction
+                  processing
+                </p>
               </div>
 
               <div className="space-y-3 mb-6 flex-grow">
                 <div className="flex items-start gap-2">
                   <Check className="w-5 h-5 text-gray-800 group-hover:text-white flex-shrink-0 mt-0.5" />
-                  <span className="text-xs text-gray-600 group-hover:text-gray-100">Upto 500 transactions per day</span>
+                  <span className="text-xs text-gray-600 group-hover:text-gray-100">
+                    Upto 500 transactions per day
+                  </span>
                 </div>
                 <div className="flex items-start gap-2">
                   <Check className="w-5 h-5 text-gray-800 group-hover:text-white flex-shrink-0 mt-0.5" />
-                  <span className="text-xs text-gray-600 group-hover:text-gray-100">Standard monthly transaction limit</span>
+                  <span className="text-xs text-gray-600 group-hover:text-gray-100">
+                    Standard monthly transaction limit
+                  </span>
                 </div>
                 <div className="flex items-start gap-2">
                   <Check className="w-5 h-5 text-gray-800 group-hover:text-white flex-shrink-0 mt-0.5" />
-                  <span className="text-xs text-gray-600 group-hover:text-gray-100">Standard support</span>
+                  <span className="text-xs text-gray-600 group-hover:text-gray-100">
+                    Standard support
+                  </span>
                 </div>
               </div>
 
-              <button onClick={() => openCheckoutFor('basic')} className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium transition-colors group-hover:bg-white group-hover:text-[#052343]">
+              <button
+                onClick={() => openCheckoutFor("basic")}
+                className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium transition-colors group-hover:bg-white group-hover:text-[#052343]"
+              >
                 Buy Now
               </button>
               <div className="flex justify-center mt-3">
-                <button onClick={() => navigate(`/pricing/${productSlug}/compare`)} className="text-xs text-gray-600 underline group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3]">
+                <button
+                  onClick={() => navigate(`/pricing/${productSlug}/compare`)}
+                  className="text-xs text-gray-600 underline group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3]"
+                >
                   See more
                 </button>
               </div>
@@ -318,45 +402,71 @@ export default function ProductPricing() {
 
           {/* Pro Plan - Best Seller */}
           <div className="relative overflow-hidden group bg-white rounded-2xl shadow-xl p-6 md:p-8 flex flex-col min-h-[28rem]">
-            <div className="absolute top-2 right-2 bg-[#FFCD38] px-3 py-1 rounded text-xs font-medium z-20">Best Seller</div>
+            <div className="absolute top-2 right-2 bg-[#FFCD38] px-3 py-1 rounded text-xs font-medium z-20">
+              Best Seller
+            </div>
 
             <div className="absolute inset-0 bg-gradient-to-b from-[#2CADE3] to-[#052343] opacity-0 transition-opacity duration-300 group-hover:opacity-100"></div>
 
             <div className="relative z-10 text-gray-900 group-hover:text-white">
               <div className="text-center mb-6">
-                <h3 className="text-2xl md:text-3xl font-semibold mb-2">{planDetails.pro.title}</h3>
-                <p className="text-base mb-3 group-hover:text-white">{billingCycle === 'yearly' ? planDetails.pro.priceYearly : planDetails.pro.priceMonthly}</p>
-                <p className="text-xs text-gray-600 group-hover:text-gray-100">For growing merchants needing higher throughput and stability</p>
+                <h3 className="text-2xl md:text-3xl font-semibold mb-2">
+                  {planDetails.pro.title}
+                </h3>
+                <p className="text-base mb-3 group-hover:text-white">
+                  {billingCycle === "yearly"
+                    ? planDetails.pro.priceYearly
+                    : planDetails.pro.priceMonthly}
+                </p>
+                <p className="text-xs text-gray-600 group-hover:text-gray-100">
+                  For growing merchants needing higher throughput and stability
+                </p>
               </div>
 
               <div className="space-y-3 mb-6 flex-grow">
                 <div className="flex items-start gap-2">
                   <Check className="w-5 h-5 text-gray-800 group-hover:text-white flex-shrink-0 mt-0.5" />
-                  <span className="text-sm group-hover:text-gray-100">1,000+ transactions per day</span>
+                  <span className="text-sm group-hover:text-gray-100">
+                    1,000+ transactions per day
+                  </span>
                 </div>
                 <div className="flex items-start gap-2">
                   <Check className="w-5 h-5 text-gray-800 group-hover:text-white flex-shrink-0 mt-0.5" />
-                  <span className="text-sm group-hover:text-gray-100">Reduced per-transaction rate</span>
+                  <span className="text-sm group-hover:text-gray-100">
+                    Reduced per-transaction rate
+                  </span>
                 </div>
                 <div className="flex items-start gap-2">
                   <Check className="w-5 h-5 text-gray-800 group-hover:text-white flex-shrink-0 mt-0.5" />
-                  <span className="text-sm group-hover:text-gray-100">High transaction limits</span>
+                  <span className="text-sm group-hover:text-gray-100">
+                    High transaction limits
+                  </span>
                 </div>
                 <div className="flex items-start gap-2">
                   <Check className="w-5 h-5 text-gray-800 group-hover:text-white flex-shrink-0 mt-0.5" />
-                  <span className="text-sm group-hover:text-gray-100">Priority support</span>
+                  <span className="text-sm group-hover:text-gray-100">
+                    Priority support
+                  </span>
                 </div>
                 <div className="flex items-start gap-2">
                   <Check className="w-5 h-5 text-gray-800 group-hover:text-white flex-shrink-0 mt-0.5" />
-                  <span className="text-sm group-hover:text-gray-100">Access to Value-Added Services (VAS)</span>
+                  <span className="text-sm group-hover:text-gray-100">
+                    Access to Value-Added Services (VAS)
+                  </span>
                 </div>
               </div>
 
-              <button onClick={() => openCheckoutFor('pro')} className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium transition-colors group-hover:bg-white group-hover:text-[#052343]">
+              <button
+                onClick={() => openCheckoutFor("pro")}
+                className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium transition-colors group-hover:bg-white group-hover:text-[#052343]"
+              >
                 Buy Now
               </button>
               <div className="flex justify-center mt-3">
-                <button onClick={() => navigate(`/pricing/${productSlug}/compare`)} className="text-xs text-gray-600 underline group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3]">
+                <button
+                  onClick={() => navigate(`/pricing/${productSlug}/compare`)}
+                  className="text-xs text-gray-600 underline group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3]"
+                >
                   See more
                 </button>
               </div>
@@ -369,31 +479,49 @@ export default function ProductPricing() {
 
             <div className="relative z-10 text-gray-900 group-hover:text-white">
               <div className="text-center mb-6">
-                <h3 className="text-2xl md:text-3xl font-semibold mb-2">{planDetails.enterprise.title}</h3>
-                <p className="text-sm text-gray-600 mb-4 group-hover:text-gray-100">{billingCycle === 'yearly' ? planDetails.enterprise.priceYearly : planDetails.enterprise.priceMonthly}</p>
-                <p className="text-xs text-gray-600 group-hover:text-gray-100">For large-scale merchants requiring dedicated infrastructure</p>
+                <h3 className="text-2xl md:text-3xl font-semibold mb-2">
+                  {planDetails.enterprise.title}
+                </h3>
+                <p className="text-sm text-gray-600 mb-4 group-hover:text-gray-100">
+                  {billingCycle === "yearly"
+                    ? planDetails.enterprise.priceYearly
+                    : planDetails.enterprise.priceMonthly}
+                </p>
+                <p className="text-xs text-gray-600 group-hover:text-gray-100">
+                  For large-scale merchants requiring dedicated infrastructure
+                </p>
               </div>
 
               <div className="space-y-3 mb-6 flex-grow">
                 <div className="flex items-start gap-2">
                   <Check className="w-5 h-5 text-gray-800 group-hover:text-white flex-shrink-0 mt-0.5" />
-                  <span className="text-xs text-gray-600 group-hover:text-gray-100">5,000+ transactions per day</span>
+                  <span className="text-xs text-gray-600 group-hover:text-gray-100">
+                    5,000+ transactions per day
+                  </span>
                 </div>
                 <div className="flex items-start gap-2">
                   <Check className="w-5 h-5 text-gray-800 group-hover:text-white flex-shrink-0 mt-0.5" />
-                  <span className="text-xs text-gray-600 group-hover:text-gray-100">Unlimited transactions</span>
+                  <span className="text-xs text-gray-600 group-hover:text-gray-100">
+                    Unlimited transactions
+                  </span>
                 </div>
                 <div className="flex items-start gap-2">
                   <Check className="w-5 h-5 text-gray-800 group-hover:text-white flex-shrink-0 mt-0.5" />
-                  <span className="text-xs text-gray-600 group-hover:text-gray-100">Volume-based pricing</span>
+                  <span className="text-xs text-gray-600 group-hover:text-gray-100">
+                    Volume-based pricing
+                  </span>
                 </div>
                 <div className="flex items-start gap-2">
                   <Check className="w-5 h-5 text-gray-800 group-hover:text-white flex-shrink-0 mt-0.5" />
-                  <span className="text-xs text-gray-600 group-hover:text-gray-100">24×7 dedicated support</span>
+                  <span className="text-xs text-gray-600 group-hover:text-gray-100">
+                    24×7 dedicated support
+                  </span>
                 </div>
                 <div className="flex items-start gap-2">
                   <Check className="w-5 h-5 text-gray-800 group-hover:text-white flex-shrink-0 mt-0.5" />
-                  <span className="text-xs text-gray-600 group-hover:text-gray-100">Client-side deployment options</span>
+                  <span className="text-xs text-gray-600 group-hover:text-gray-100">
+                    Client-side deployment options
+                  </span>
                 </div>
               </div>
 
@@ -401,7 +529,10 @@ export default function ProductPricing() {
                 Contact Now
               </button>
               <div className="flex justify-center mt-3">
-                <button onClick={() => navigate(`/pricing/${productSlug}/compare`)} className="text-xs text-gray-600 underline group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3]">
+                <button
+                  onClick={() => navigate(`/pricing/${productSlug}/compare`)}
+                  className="text-xs text-gray-600 underline group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3]"
+                >
                   See more
                 </button>
               </div>
@@ -415,12 +546,18 @@ export default function ProductPricing() {
         <DialogPortal>
           <DialogOverlay className="bg-white/70 backdrop-blur-md" />
           <DialogContent className="max-w-md p-4 sm:p-6 rounded-xl shadow-2xl">
-            <DialogTitle className="sr-only">Join Our Trial on Token X</DialogTitle>
+            <DialogTitle className="sr-only">
+              Join Our Trial on Token X
+            </DialogTitle>
 
             <div className="p-4 sm:p-6">
               <div className="text-center mb-4">
-                <h2 className="text-xl md:text-2xl font-bold text-[#1E3A8A] mb-1">Join Our Trial on</h2>
-                <h3 className="text-xl md:text-2xl font-bold text-[#2CADE3]">Token X</h3>
+                <h2 className="text-xl md:text-2xl font-bold text-[#1E3A8A] mb-1">
+                  Join Our Trial on
+                </h2>
+                <h3 className="text-xl md:text-2xl font-bold text-[#2CADE3]">
+                  Token X
+                </h3>
               </div>
 
               <div className="space-y-3">
@@ -444,7 +581,9 @@ export default function ProductPricing() {
                 </button>
               </div>
 
-              <p className="text-center text-gray-500 text-xs mt-4">Submit your email address to join the trial plan</p>
+              <p className="text-center text-gray-500 text-xs mt-4">
+                Submit your email address to join the trial plan
+              </p>
             </div>
           </DialogContent>
         </DialogPortal>
@@ -461,7 +600,9 @@ export default function ProductPricing() {
               <div className="flex items-start justify-between mb-4">
                 <div>
                   <h2 className="text-xl font-bold text-[#1E3A8A]">Checkout</h2>
-                  <p className="text-sm text-gray-600">Please confirm your details to proceed to payment</p>
+                  <p className="text-sm text-gray-600">
+                    Please confirm your details to proceed to payment
+                  </p>
                 </div>
               </div>
 
@@ -470,11 +611,15 @@ export default function ProductPricing() {
                   <div className="flex items-center justify-between">
                     <div>
                       <p className="text-sm text-gray-500">Selected plan</p>
-                      <p className="font-semibold text-gray-900">{checkoutPlan.title}</p>
+                      <p className="font-semibold text-gray-900">
+                        {checkoutPlan.title}
+                      </p>
                     </div>
                     <div className="text-right">
                       <p className="text-sm text-gray-500">Amount</p>
-                      <p className="font-semibold text-gray-900">{checkoutPlan.price}</p>
+                      <p className="font-semibold text-gray-900">
+                        {checkoutPlan.price}
+                      </p>
                     </div>
                   </div>
                 </div>
@@ -482,16 +627,42 @@ export default function ProductPricing() {
 
               <div className="space-y-3">
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-                  <input type="text" placeholder="First name" value={checkoutFirstName} onChange={(e) => setCheckoutFirstName(e.target.value)} className="w-full px-3 py-2 border border-black/30 rounded-md text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#2CADE3] focus:border-transparent" />
-                  <input type="text" placeholder="Last name" value={checkoutLastName} onChange={(e) => setCheckoutLastName(e.target.value)} className="w-full px-3 py-2 border border-black/30 rounded-md text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#2CADE3] focus:border-transparent" />
+                  <input
+                    type="text"
+                    placeholder="First name"
+                    value={checkoutFirstName}
+                    onChange={(e) => setCheckoutFirstName(e.target.value)}
+                    className="w-full px-3 py-2 border border-black/30 rounded-md text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#2CADE3] focus:border-transparent"
+                  />
+                  <input
+                    type="text"
+                    placeholder="Last name"
+                    value={checkoutLastName}
+                    onChange={(e) => setCheckoutLastName(e.target.value)}
+                    className="w-full px-3 py-2 border border-black/30 rounded-md text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#2CADE3] focus:border-transparent"
+                  />
                 </div>
 
-                <input type="email" placeholder="Email address" value={checkoutEmail} onChange={(e) => setCheckoutEmail(e.target.value)} className="w-full px-3 py-2 border border-black/30 rounded-md text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#2CADE3] focus:border-transparent" />
+                <input
+                  type="email"
+                  placeholder="Email address"
+                  value={checkoutEmail}
+                  onChange={(e) => setCheckoutEmail(e.target.value)}
+                  className="w-full px-3 py-2 border border-black/30 rounded-md text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#2CADE3] focus:border-transparent"
+                />
 
-                <button onClick={handleProceedToPay} className="w-full bg-[#2CADE3] text-white py-2 rounded-md text-sm font-medium hover:bg-[#2399c9] transition-colors">Proceed to Pay</button>
+                <button
+                  onClick={handleProceedToPay}
+                  className="w-full bg-[#2CADE3] text-white py-2 rounded-md text-sm font-medium hover:bg-[#2399c9] transition-colors"
+                >
+                  Proceed to Pay
+                </button>
               </div>
 
-              <p className="text-center text-gray-500 text-xs mt-4">You will be redirected to the payment gateway after clicking "Proceed to Pay".</p>
+              <p className="text-center text-gray-500 text-xs mt-4">
+                You will be redirected to the payment gateway after clicking
+                "Proceed to Pay".
+              </p>
             </div>
           </DialogContent>
         </DialogPortal>
@@ -507,7 +678,9 @@ export default function ProductPricing() {
             <div className="p-4 sm:p-6">
               <div className="flex items-start justify-between mb-4">
                 <div>
-                  <h2 className="text-xl font-bold text-[#1E3A8A]">Payment Result</h2>
+                  <h2 className="text-xl font-bold text-[#1E3A8A]">
+                    Payment Result
+                  </h2>
                   <p className="text-sm text-gray-600">Transaction details</p>
                 </div>
               </div>
@@ -516,34 +689,51 @@ export default function ProductPricing() {
                 <div className="space-y-3">
                   <div className="p-3 border rounded-md bg-white">
                     <p className="text-sm text-gray-600">Status</p>
-                    <p className="font-semibold">{resultDetails.ok ? "Success" : "Failed"}</p>
+                    <p className="font-semibold">
+                      {resultDetails.ok ? "Success" : "Failed"}
+                    </p>
                   </div>
 
                   {resultDetails.paymentResponse?.razorpay_payment_id && (
                     <div className="p-3 border rounded-md bg-white">
                       <p className="text-sm text-gray-600">Payment ID</p>
-                      <p className="font-semibold">{resultDetails.paymentResponse.razorpay_payment_id}</p>
+                      <p className="font-semibold">
+                        {resultDetails.paymentResponse.razorpay_payment_id}
+                      </p>
                     </div>
                   )}
 
                   {resultDetails.paymentResponse?.razorpay_order_id && (
                     <div className="p-3 border rounded-md bg-white">
                       <p className="text-sm text-gray-600">Order ID</p>
-                      <p className="font-semibold">{resultDetails.paymentResponse.razorpay_order_id}</p>
+                      <p className="font-semibold">
+                        {resultDetails.paymentResponse.razorpay_order_id}
+                      </p>
                     </div>
                   )}
 
                   {resultDetails.verifyData && (
                     <div className="p-3 border rounded-md bg-white">
                       <p className="text-sm text-gray-600">Verification</p>
-                      <p className="font-semibold">{resultDetails.verifyData.ok ? "Signature valid" : resultDetails.verifyData.error}</p>
+                      <p className="font-semibold">
+                        {resultDetails.verifyData.ok
+                          ? "Signature valid"
+                          : resultDetails.verifyData.error}
+                      </p>
                     </div>
                   )}
 
-                  <button onClick={() => setShowResultModal(false)} className="w-full bg-[#2CADE3] text-white py-2 rounded-md text-sm font-medium hover:bg-[#2399c9] transition-colors">Close</button>
+                  <button
+                    onClick={() => setShowResultModal(false)}
+                    className="w-full bg-[#2CADE3] text-white py-2 rounded-md text-sm font-medium hover:bg-[#2399c9] transition-colors"
+                  >
+                    Close
+                  </button>
                 </div>
               ) : (
-                <p className="text-sm text-gray-600">No transaction details available.</p>
+                <p className="text-sm text-gray-600">
+                  No transaction details available.
+                </p>
               )}
             </div>
           </DialogContent>

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -64,9 +64,9 @@ export default function ProductPricing() {
 
           {/* Billing Toggle */}
           <div className="flex items-center justify-end gap-3 mt-8">
-            <div className="text-right">
-              <span className="text-xs font-semibold">Save 15%</span>
-              <div className="text-xs text-gray-600">on yearly plan!</div>
+            <div className="text-right whitespace-nowrap">
+              <span className="text-xs font-semibold mr-2">Save 15%</span>
+              <span className="text-xs text-gray-600">on yearly plan!</span>
             </div>
             <div className="flex items-center gap-1 p-1 border border-gray-200 rounded-full bg-white">
               <button

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -63,13 +63,15 @@ export default function ProductPricing() {
           </h1>
 
           {/* Billing Toggle */}
-          <div className="flex items-center justify-center gap-3 mt-8">
-            <span className="text-sm font-bold">Save 15%</span>
-            <span className="text-sm">on yearly plan!</span>
+          <div className="flex items-center justify-end gap-3 mt-8">
+            <div className="text-right">
+              <span className="text-xs font-semibold">Save 15%</span>
+              <div className="text-xs text-gray-600">on yearly plan!</div>
+            </div>
             <div className="flex items-center gap-1 p-1 border border-gray-200 rounded-full bg-white">
               <button
                 onClick={() => setBillingCycle("yearly")}
-                className={`px-4 py-2 rounded-full text-sm font-semibold transition-all ${
+                className={`px-3 py-1 rounded-full text-xs font-semibold transition-all ${
                   billingCycle === "yearly"
                     ? "bg-blue-900 text-white"
                     : "text-gray-800"
@@ -79,7 +81,7 @@ export default function ProductPricing() {
               </button>
               <button
                 onClick={() => setBillingCycle("monthly")}
-                className={`px-4 py-2 rounded-full text-sm font-semibold transition-all ${
+                className={`px-3 py-1 rounded-full text-xs font-semibold transition-all ${
                   billingCycle === "monthly"
                     ? "bg-blue-900 text-white"
                     : "text-gray-800"

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -103,9 +103,9 @@ export default function ProductPricing() {
     try {
       const axios = (await import('axios')).default;
       const productName = product?.name ? product.name.toLowerCase() : 'tokenx';
-      const resp = await axios.post('https://apisandbox-nonprod.mylapay.com/mylapay/v1/mylapay_site/require-otp', { email: trialEmail, productName, otp: trialOtp });
+      const resp = await axios.post('/api/mylapay/require-otp', { email: trialEmail, productName, otp: trialOtp });
       const data = resp.data;
-      if (data && data.ok) {
+      if (data && (data.ok === true || data.ok === 'true')) {
         toast({ title: data.message || 'Success', description: '' });
         setShowTrialModal(false);
         setTrialEmail('');
@@ -113,7 +113,8 @@ export default function ProductPricing() {
         setTrialOtp('');
         setTrialOtpExpiresAt(null);
       } else {
-        toast({ title: 'OTP verification failed', description: String(data?.message || data?.error || 'Invalid OTP') });
+        const msg = data?.message || data?.error || JSON.stringify(data);
+        toast({ title: 'OTP verification failed', description: String(msg) });
       }
     } catch (err: any) {
       console.error('Verify OTP error', err);

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -309,6 +309,58 @@ export default function ProductPricing() {
           </div>
         </div>
       </div>
+
+      {/* Trial Signup Modal */}
+      <Dialog open={showTrialModal} onOpenChange={setShowTrialModal}>
+        <DialogPortal>
+          <DialogOverlay className="bg-black/60" />
+          <DialogContent className="max-w-lg sm:max-w-xl md:max-w-2xl p-0 gap-0 border-0 rounded-2xl shadow-2xl">
+            <button
+              onClick={() => setShowTrialModal(false)}
+              className="absolute right-6 top-6 z-10 rounded-sm opacity-70 hover:opacity-100 transition-opacity"
+              aria-label="Close"
+            >
+              <X className="h-8 w-8" />
+            </button>
+
+            <div className="p-8 md:p-12">
+              <div className="text-center mb-8">
+                <h2 className="text-3xl md:text-4xl font-bold text-[#1E3A8A] mb-2">
+                  Join Our Trail on
+                </h2>
+                <h3 className="text-3xl md:text-4xl font-bold text-[#2CADE3]">
+                  Token X
+                </h3>
+              </div>
+
+              <div className="space-y-4">
+                <input
+                  type="email"
+                  placeholder="Email address"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  className="w-full px-4 py-3 border border-black/50 rounded-md text-base placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#2CADE3] focus:border-transparent"
+                />
+
+                <button
+                  onClick={() => {
+                    console.log("Trial signup with email:", email);
+                    setShowTrialModal(false);
+                    setEmail("");
+                  }}
+                  className="w-full bg-[#2CADE3] text-white py-3 rounded-md text-base font-normal hover:bg-[#2399c9] transition-colors"
+                >
+                  Try now the trial
+                </button>
+              </div>
+
+              <p className="text-center text-gray-500 text-sm mt-6">
+                Submit your email address to join the trail plan
+              </p>
+            </div>
+          </DialogContent>
+        </DialogPortal>
+      </Dialog>
     </div>
   );
 }

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -31,7 +31,6 @@ const products = [
 export default function ProductPricing() {
   const { productSlug } = useParams<{ productSlug: string }>();
   const navigate = useNavigate();
-  const navigateToCompare = useNavigate();
   const [billingCycle, setBillingCycle] = useState<"yearly" | "monthly">(
     "yearly",
   );

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -1,6 +1,7 @@
 import { useParams, useNavigate } from "react-router-dom";
 import { Check, X } from "lucide-react";
 import { useState } from "react";
+import { toast } from "@/hooks/use-toast";
 import {
   Dialog,
   DialogContent,

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -122,15 +122,14 @@ export default function ProductPricing() {
 
       let data: any;
       try {
-        data = await resp.json();
-      } catch (e) {
-        // fallback if body already read or invalid json
+        const txt = await resp.text();
         try {
-          const txt = await resp.text();
           data = txt ? JSON.parse(txt) : { ok: false, error: "Empty response" };
-        } catch (err) {
-          data = { ok: false, error: String(err || e) };
+        } catch (parseErr) {
+          data = { ok: false, error: String(parseErr), raw: txt };
         }
+      } catch (e) {
+        data = { ok: false, error: String(e) };
       }
 
       if (!data || !data.ok) throw new Error(data?.error || "Failed to create order");

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -123,7 +123,7 @@ export default function ProductPricing() {
       // Read response text once and parse
       let data: any = null;
       try {
-        const txt = await resp.text();
+        const txt = await resp.clone().text();
         data = txt ? JSON.parse(txt) : { ok: false, error: "Empty response" };
       } catch (err) {
         data = { ok: false, error: String(err) };

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -316,6 +316,7 @@ export default function ProductPricing() {
         <DialogPortal>
           <DialogOverlay className="bg-black/60" />
           <DialogContent className="max-w-lg sm:max-w-xl md:max-w-2xl p-0 gap-0 border-0 rounded-2xl shadow-2xl">
+            <DialogTitle className="sr-only">Join Our Trial on Token X</DialogTitle>
             <button
               onClick={() => setShowTrialModal(false)}
               className="absolute right-6 top-6 z-10 rounded-sm opacity-70 hover:opacity-100 transition-opacity"

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -145,6 +145,11 @@ export default function ProductPricing() {
       const loaded = await loadRazorpayScript();
       if (!loaded) throw new Error("Failed to load Razorpay SDK");
 
+      // Close our checkout modal so Razorpay widget is clickable
+      setShowCheckoutModal(false);
+      // wait a tick so overlay is removed from DOM
+      await new Promise((res) => setTimeout(res, 120));
+
       // Open Razorpay Checkout
       const options: any = {
         key: keyId,

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -159,23 +159,10 @@ export default function ProductPricing() {
 
           let verifyData: any = null;
           try {
-            try {
-              verifyData = await verifyRes.clone().json();
-            } catch (je) {
-              const txtv = await verifyRes.clone().text();
-              try {
-                verifyData = txtv ? JSON.parse(txtv) : { ok: false, error: "Empty verify response" };
-              } catch (pe) {
-                verifyData = { ok: false, error: String(pe), raw: txtv };
-              }
-            }
+            const txtv = await verifyRes.text();
+            verifyData = txtv ? JSON.parse(txtv) : { ok: false, error: "Empty verify response" };
           } catch (err) {
-            try {
-              const txtv = await verifyRes.text();
-              verifyData = txtv ? JSON.parse(txtv) : { ok: false, error: "Empty verify response" };
-            } catch (finalErr) {
-              verifyData = { ok: false, error: String(finalErr) };
-            }
+            verifyData = { ok: false, error: String(err) };
           }
 
           const details = {

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -162,14 +162,14 @@ export default function ProductPricing() {
 
           let verifyData: any;
           try {
-            verifyData = await verifyRes.json();
-          } catch (err) {
+            const txtv = await verifyRes.text();
             try {
-              const txt = await verifyRes.text();
-              verifyData = txt ? JSON.parse(txt) : { ok: false, error: "Empty verify response" };
-            } catch (e2) {
-              verifyData = { ok: false, error: String(e2 || err) };
+              verifyData = txtv ? JSON.parse(txtv) : { ok: false, error: "Empty verify response" };
+            } catch (parseErr2) {
+              verifyData = { ok: false, error: String(parseErr2), raw: txtv };
             }
+          } catch (err) {
+            verifyData = { ok: false, error: String(err) };
           }
 
           const details = {

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -186,8 +186,8 @@ export default function ProductPricing() {
 
             <div className="relative z-10 text-gray-900 group-hover:text-white">
               <div className="text-center mb-6">
-                <h3 className="text-3xl md:text-4xl font-semibold mb-2">Pro Plan</h3>
-                <p className="text-lg mb-3 group-hover:text-white">$$$/ Year</p>
+                <h3 className="text-2xl md:text-3xl font-semibold mb-2">Pro Plan</h3>
+                <p className="text-base mb-3 group-hover:text-white">$$$/ Year</p>
                 <p className="text-xs text-gray-600 group-hover:text-gray-100">
                   For growing merchants needing higher throughput and stability
                 </p>
@@ -236,7 +236,7 @@ export default function ProductPricing() {
 
             <div className="relative z-10 text-gray-900 group-hover:text-white">
               <div className="text-center mb-6">
-                <h3 className="text-3xl md:text-4xl font-semibold mb-2">Enterprise Plan</h3>
+                <h3 className="text-2xl md:text-3xl font-semibold mb-2">Enterprise Plan</h3>
                 <p className="text-sm text-gray-600 mb-4 group-hover:text-gray-100">
                   For large-scale merchants requiring dedicated infrastructure
                 </p>

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -71,54 +71,73 @@ export default function ProductPricing() {
   // Trial modal state
   const [showTrialModal, setShowTrialModal] = useState(false);
   const [trialEmail, setTrialEmail] = useState("");
-  const [trialStage, setTrialStage] = useState<'email' | 'otp'>('email');
+  const [trialStage, setTrialStage] = useState<"email" | "otp">("email");
   const [trialOtp, setTrialOtp] = useState("");
-  const [trialOtpExpiresAt, setTrialOtpExpiresAt] = useState<number | null>(null);
+  const [trialOtpExpiresAt, setTrialOtpExpiresAt] = useState<number | null>(
+    null,
+  );
 
   // Functions for OTP flow
   async function sendTrialOtp() {
-    if (!trialEmail) return alert('Enter an email to receive OTP');
+    if (!trialEmail) return alert("Enter an email to receive OTP");
     try {
-      const axios = (await import('axios')).default;
-      const productName = product?.name ? product.name.toLowerCase() : 'tokenx';
-      const resp = await axios.post('/api/mylapay/require-otp', { email: trialEmail, productName });
+      const axios = (await import("axios")).default;
+      const productName = product?.name ? product.name.toLowerCase() : "tokenx";
+      const resp = await axios.post("/api/mylapay/require-otp", {
+        email: trialEmail,
+        productName,
+      });
       const data = resp.data;
-      if (data && (data.ok === true || data.ok === 'true')) {
-        setTrialStage('otp');
-        setTrialOtp('');
+      if (data && (data.ok === true || data.ok === "true")) {
+        setTrialStage("otp");
+        setTrialOtp("");
         setTrialOtpExpiresAt(Date.now() + 5 * 60 * 1000);
-        toast({ title: 'OTP sent', description: 'Please check your email and enter the 6-digit OTP (expires in 5 minutes).' });
+        toast({
+          title: "OTP sent",
+          description:
+            "Please check your email and enter the 6-digit OTP (expires in 5 minutes).",
+        });
       } else {
         const msg = data?.message || data?.error || JSON.stringify(data);
-        toast({ title: 'Failed to send OTP', description: String(msg) });
+        toast({ title: "Failed to send OTP", description: String(msg) });
       }
     } catch (err: any) {
-      console.error('Send OTP error', err);
-      toast({ title: 'Send OTP failed', description: err?.message || String(err) });
+      console.error("Send OTP error", err);
+      toast({
+        title: "Send OTP failed",
+        description: err?.message || String(err),
+      });
     }
   }
 
   async function verifyTrialOtp() {
-    if (!trialOtp) return alert('Enter the OTP');
+    if (!trialOtp) return alert("Enter the OTP");
     try {
-      const axios = (await import('axios')).default;
-      const productName = product?.name ? product.name.toLowerCase() : 'tokenx';
-      const resp = await axios.post('/api/mylapay/require-otp', { email: trialEmail, productName, otp: trialOtp });
+      const axios = (await import("axios")).default;
+      const productName = product?.name ? product.name.toLowerCase() : "tokenx";
+      const resp = await axios.post("/api/mylapay/require-otp", {
+        email: trialEmail,
+        productName,
+        otp: trialOtp,
+      });
       const data = resp.data;
-      if (data && (data.ok === true || data.ok === 'true')) {
-        toast({ title: data.message || 'Success', description: '' });
+      if (data && (data.ok === true || data.ok === "true")) {
+        toast({ title: data.message || "Success", description: "" });
         setShowTrialModal(false);
-        setTrialEmail('');
-        setTrialStage('email');
-        setTrialOtp('');
+        setTrialEmail("");
+        setTrialStage("email");
+        setTrialOtp("");
         setTrialOtpExpiresAt(null);
       } else {
         const msg = data?.message || data?.error || JSON.stringify(data);
-        toast({ title: 'OTP verification failed', description: String(msg) });
+        toast({ title: "OTP verification failed", description: String(msg) });
       }
     } catch (err: any) {
-      console.error('Verify OTP error', err);
-      toast({ title: 'Verify OTP failed', description: err?.message || String(err) });
+      console.error("Verify OTP error", err);
+      toast({
+        title: "Verify OTP failed",
+        description: err?.message || String(err),
+      });
     }
   }
 
@@ -612,7 +631,7 @@ export default function ProductPricing() {
               </div>
 
               <div className="space-y-3">
-                {trialStage === 'email' ? (
+                {trialStage === "email" ? (
                   <>
                     <input
                       type="email"
@@ -631,7 +650,10 @@ export default function ProductPricing() {
                   </>
                 ) : (
                   <>
-                    <p className="text-sm text-gray-600">Enter the 6-digit OTP sent to your email. Expires in 5 minutes.</p>
+                    <p className="text-sm text-gray-600">
+                      Enter the 6-digit OTP sent to your email. Expires in 5
+                      minutes.
+                    </p>
                     <input
                       type="text"
                       placeholder="Enter OTP"

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -135,35 +135,18 @@ export default function ProductPricing() {
         description: checkoutPlan.title,
         order_id: order.id,
         handler: async function (response: any) {
-          // Verify signature on server
-          const verifyRes = await fetch("/api/razorpay/verify", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
+          // Verify signature on server using axios
+          const axios = (await import("axios")).default;
+          let verifyData: any = null;
+          try {
+            const vr = await axios.post("/api/razorpay/verify", {
               razorpay_order_id: response.razorpay_order_id,
               razorpay_payment_id: response.razorpay_payment_id,
               razorpay_signature: response.razorpay_signature,
-            }),
-          });
-
-          let verifyData: any = null;
-          try {
-            if (verifyRes.bodyUsed) {
-              verifyData = { ok: false, error: "Verify response body already used" };
-            } else {
-              try {
-                verifyData = await verifyRes.json();
-              } catch (jerr) {
-                try {
-                  const txtv = await verifyRes.text();
-                  verifyData = txtv ? JSON.parse(txtv) : { ok: false, error: "Empty verify response" };
-                } catch (terr) {
-                  verifyData = { ok: false, error: String(terr || jerr) };
-                }
-              }
-            }
-          } catch (err) {
-            verifyData = { ok: false, error: String(err) };
+            });
+            verifyData = vr.data;
+          } catch (err: any) {
+            verifyData = { ok: false, error: err?.message || String(err) };
           }
 
           const details = {

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -94,7 +94,7 @@ export default function ProductPricing() {
         {/* Pricing Cards */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 items-stretch">
           {/* Trial Plan */}
-          <div className="relative overflow-hidden group bg-white rounded-2xl shadow-xl p-6 md:p-8 flex flex-col min-h-[16rem]">
+          <div className="relative overflow-hidden group bg-white rounded-2xl shadow-xl p-6 md:p-8 flex flex-col min-h-[12rem]">
             <div className="absolute inset-0 bg-gradient-to-b from-[#2CADE3] to-[#052343] opacity-0 transition-opacity duration-300 group-hover:opacity-100"></div>
 
             <div className="relative z-10 text-gray-900 group-hover:text-white">
@@ -132,7 +132,7 @@ export default function ProductPricing() {
           </div>
 
           {/* Basic Plan */}
-          <div className="relative overflow-hidden group bg-white rounded-2xl shadow-xl p-6 md:p-8 flex flex-col min-h-[20rem]">
+          <div className="relative overflow-hidden group bg-white rounded-2xl shadow-xl p-6 md:p-8 flex flex-col min-h-[18rem]">
             <div className="absolute inset-0 bg-gradient-to-b from-[#2CADE3] to-[#052343] opacity-0 transition-opacity duration-300 group-hover:opacity-100"></div>
 
             <div className="relative z-10 text-gray-900 group-hover:text-white">
@@ -177,7 +177,7 @@ export default function ProductPricing() {
           </div>
 
           {/* Pro Plan - Best Seller */}
-          <div className="relative overflow-hidden group bg-white rounded-2xl shadow-xl p-6 md:p-8 flex flex-col min-h-[24rem]">
+          <div className="relative overflow-hidden group bg-white rounded-2xl shadow-xl p-6 md:p-8 flex flex-col min-h-[26rem]">
             <div className="absolute top-2 right-2 bg-[#FFCD38] px-3 py-1 rounded text-xs font-medium z-20">
               Best Seller
             </div>
@@ -231,7 +231,7 @@ export default function ProductPricing() {
           </div>
 
           {/* Enterprise Plan */}
-          <div className="relative overflow-hidden group bg-white rounded-2xl shadow-xl p-6 md:p-8 flex flex-col min-h-[28rem]">
+          <div className="relative overflow-hidden group bg-white rounded-2xl shadow-xl p-6 md:p-8 flex flex-col min-h-[32rem]">
             <div className="absolute inset-0 bg-gradient-to-b from-[#2CADE3] to-[#052343] opacity-0 transition-opacity duration-300 group-hover:opacity-100"></div>
 
             <div className="relative z-10 text-gray-900 group-hover:text-white">

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -186,7 +186,7 @@ export default function ProductPricing() {
 
             <div className="relative z-10 text-gray-900 group-hover:text-white">
               <div className="text-center mb-6">
-                <h3 className="text-2xl font-semibold mb-2">Pro Plan</h3>
+                <h3 className="text-3xl md:text-4xl font-semibold mb-2">Pro Plan</h3>
                 <p className="text-lg mb-3 group-hover:text-white">$$$/ Year</p>
                 <p className="text-xs text-gray-600 group-hover:text-gray-100">
                   For growing merchants needing higher throughput and stability
@@ -231,12 +231,12 @@ export default function ProductPricing() {
           </div>
 
           {/* Enterprise Plan */}
-          <div className="relative overflow-hidden group bg-white rounded-2xl shadow-xl p-6 md:p-8 flex flex-col min-h-[26rem]">
+          <div className="relative overflow-hidden group bg-white rounded-2xl shadow-xl p-6 md:p-8 flex flex-col min-h-[24rem]">
             <div className="absolute inset-0 bg-gradient-to-b from-[#2CADE3] to-[#052343] opacity-0 transition-opacity duration-300 group-hover:opacity-100"></div>
 
             <div className="relative z-10 text-gray-900 group-hover:text-white">
               <div className="text-center mb-6">
-                <h3 className="text-2xl font-semibold mb-2">Enterprise Plan</h3>
+                <h3 className="text-2xl md:text-3xl font-semibold mb-2">Enterprise Plan</h3>
                 <p className="text-sm text-gray-600 mb-4 group-hover:text-gray-100">
                   For large-scale merchants requiring dedicated infrastructure
                 </p>

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -231,12 +231,12 @@ export default function ProductPricing() {
           </div>
 
           {/* Enterprise Plan */}
-          <div className="relative overflow-hidden group bg-white rounded-2xl shadow-xl p-6 md:p-8 flex flex-col min-h-[24rem]">
+          <div className="relative overflow-hidden group bg-white rounded-2xl shadow-xl p-6 md:p-8 flex flex-col min-h-[28rem]">
             <div className="absolute inset-0 bg-gradient-to-b from-[#2CADE3] to-[#052343] opacity-0 transition-opacity duration-300 group-hover:opacity-100"></div>
 
             <div className="relative z-10 text-gray-900 group-hover:text-white">
               <div className="text-center mb-6">
-                <h3 className="text-2xl md:text-3xl font-semibold mb-2">Enterprise Plan</h3>
+                <h3 className="text-3xl md:text-4xl font-semibold mb-2">Enterprise Plan</h3>
                 <p className="text-sm text-gray-600 mb-4 group-hover:text-gray-100">
                   For large-scale merchants requiring dedicated infrastructure
                 </p>

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -472,6 +472,59 @@ export default function ProductPricing() {
           </DialogContent>
         </DialogPortal>
       </Dialog>
+
+      {/* Payment result modal */}
+      <Dialog open={showResultModal} onOpenChange={setShowResultModal}>
+        <DialogPortal>
+          <DialogOverlay className="bg-black/50 backdrop-blur-sm" />
+          <DialogContent className="max-w-md p-4 sm:p-6 rounded-xl shadow-2xl">
+            <DialogTitle className="sr-only">Payment Result</DialogTitle>
+
+            <div className="p-4 sm:p-6">
+              <div className="flex items-start justify-between mb-4">
+                <div>
+                  <h2 className="text-xl font-bold text-[#1E3A8A]">Payment Result</h2>
+                  <p className="text-sm text-gray-600">Transaction details</p>
+                </div>
+              </div>
+
+              {resultDetails ? (
+                <div className="space-y-3">
+                  <div className="p-3 border rounded-md bg-white">
+                    <p className="text-sm text-gray-600">Status</p>
+                    <p className="font-semibold">{resultDetails.ok ? "Success" : "Failed"}</p>
+                  </div>
+
+                  {resultDetails.paymentResponse?.razorpay_payment_id && (
+                    <div className="p-3 border rounded-md bg-white">
+                      <p className="text-sm text-gray-600">Payment ID</p>
+                      <p className="font-semibold">{resultDetails.paymentResponse.razorpay_payment_id}</p>
+                    </div>
+                  )}
+
+                  {resultDetails.paymentResponse?.razorpay_order_id && (
+                    <div className="p-3 border rounded-md bg-white">
+                      <p className="text-sm text-gray-600">Order ID</p>
+                      <p className="font-semibold">{resultDetails.paymentResponse.razorpay_order_id}</p>
+                    </div>
+                  )}
+
+                  {resultDetails.verifyData && (
+                    <div className="p-3 border rounded-md bg-white">
+                      <p className="text-sm text-gray-600">Verification</p>
+                      <p className="font-semibold">{resultDetails.verifyData.ok ? "Signature valid" : resultDetails.verifyData.error}</p>
+                    </div>
+                  )}
+
+                  <button onClick={() => setShowResultModal(false)} className="w-full bg-[#2CADE3] text-white py-2 rounded-md text-sm font-medium hover:bg-[#2399c9] transition-colors">Close</button>
+                </div>
+              ) : (
+                <p className="text-sm text-gray-600">No transaction details available.</p>
+              )}
+            </div>
+          </DialogContent>
+        </DialogPortal>
+      </Dialog>
     </div>
   );
 }

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -124,7 +124,7 @@ export default function ProductPricing() {
               <button className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium transition-colors group-hover:bg-white group-hover:text-[#052343]">
                 Try Now
               </button>
-              <div className="flex justify-center">
+              <div className="flex justify-center mt-3">
                 <button
                   onClick={() => navigate(`/pricing/${productSlug}/compare`)}
                   className="text-xs text-gray-600 underline group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3]"
@@ -171,7 +171,7 @@ export default function ProductPricing() {
               <button className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium transition-colors group-hover:bg-white group-hover:text-[#052343]">
                 Buy Now
               </button>
-              <div className="flex justify-center">
+              <div className="flex justify-center mt-3">
                 <button
                   onClick={() => navigate(`/pricing/${productSlug}/compare`)}
                   className="text-xs text-gray-600 underline group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3]"
@@ -227,7 +227,7 @@ export default function ProductPricing() {
               <button className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium transition-colors group-hover:bg-white group-hover:text-[#052343]">
                 Buy Now
               </button>
-              <div className="flex justify-center">
+              <div className="flex justify-center mt-3">
                 <button
                   onClick={() => navigate(`/pricing/${productSlug}/compare`)}
                   className="text-xs text-gray-600 underline group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3]"
@@ -286,7 +286,7 @@ export default function ProductPricing() {
               <button className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium transition-colors group-hover:bg-white group-hover:text-[#052343]">
                 Contact Now
               </button>
-              <div className="flex justify-center">
+              <div className="flex justify-center mt-3">
                 <button
                   onClick={() => navigate(`/pricing/${productSlug}/compare`)}
                   className="text-xs text-gray-600 underline group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3]"

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -364,9 +364,6 @@ export default function ProductPricing() {
                   <h2 className="text-xl font-bold text-[#1E3A8A]">Checkout</h2>
                   <p className="text-sm text-gray-600">Please confirm your details to proceed to payment</p>
                 </div>
-                <button onClick={() => setShowCheckoutModal(false)} className="text-gray-500 hover:text-gray-700">
-                  <X className="w-5 h-5" />
-                </button>
               </div>
 
               {checkoutPlan && (

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -610,24 +610,50 @@ export default function ProductPricing() {
               </div>
 
               <div className="space-y-3">
-                <input
-                  type="email"
-                  placeholder="Email address"
-                  value={trialEmail}
-                  onChange={(e) => setTrialEmail(e.target.value)}
-                  className="w-full px-3 py-2 border border-black/30 rounded-md text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#2CADE3] focus:border-transparent"
-                />
+                {trialStage === 'email' ? (
+                  <>
+                    <input
+                      type="email"
+                      placeholder="Email address"
+                      value={trialEmail}
+                      onChange={(e) => setTrialEmail(e.target.value)}
+                      className="w-full px-3 py-2 border border-black/30 rounded-md text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#2CADE3] focus:border-transparent"
+                    />
 
-                <button
-                  onClick={() => {
-                    console.log("Trial signup with email:", trialEmail);
-                    setShowTrialModal(false);
-                    setTrialEmail("");
-                  }}
-                  className="w-full bg-[#2CADE3] text-white py-2 rounded-md text-sm font-medium hover:bg-[#2399c9] transition-colors"
-                >
-                  Try now the trial
-                </button>
+                    <button
+                      onClick={sendTrialOtp}
+                      className="w-full bg-[#2CADE3] text-white py-2 rounded-md text-sm font-medium hover:bg-[#2399c9] transition-colors"
+                    >
+                      Send OTP
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    <p className="text-sm text-gray-600">Enter the 6-digit OTP sent to your email. Expires in 5 minutes.</p>
+                    <input
+                      type="text"
+                      placeholder="Enter OTP"
+                      value={trialOtp}
+                      onChange={(e) => setTrialOtp(e.target.value)}
+                      className="w-full px-3 py-2 border border-black/30 rounded-md text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#2CADE3] focus:border-transparent"
+                    />
+
+                    <div className="flex gap-2">
+                      <button
+                        onClick={verifyTrialOtp}
+                        className="flex-1 bg-[#2CADE3] text-white py-2 rounded-md text-sm font-medium hover:bg-[#2399c9] transition-colors"
+                      >
+                        Verify OTP
+                      </button>
+                      <button
+                        onClick={sendTrialOtp}
+                        className="flex-1 border border-gray-300 text-gray-700 py-2 rounded-md text-sm font-medium hover:bg-gray-50 transition-colors"
+                      >
+                        Resend
+                      </button>
+                    </div>
+                  </>
+                )}
               </div>
 
               <p className="text-center text-gray-500 text-xs mt-4">

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -314,7 +314,7 @@ export default function ProductPricing() {
       {/* Trial Signup Modal */}
       <Dialog open={showTrialModal} onOpenChange={setShowTrialModal}>
         <DialogPortal>
-          <DialogOverlay className="bg-white/30 backdrop-blur-sm" />
+          <DialogOverlay className="bg-white/70 backdrop-blur-md" />
           <DialogContent className="max-w-md p-4 sm:p-6 rounded-xl shadow-2xl">
             <DialogTitle className="sr-only">Join Our Trial on Token X</DialogTitle>
 

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -81,15 +81,16 @@ export default function ProductPricing() {
     try {
       const axios = (await import('axios')).default;
       const productName = product?.name ? product.name.toLowerCase() : 'tokenx';
-      const resp = await axios.post('https://apisandbox-nonprod.mylapay.com/mylapay/v1/mylapay_site/require-otp', { email: trialEmail, productName });
+      const resp = await axios.post('/api/mylapay/require-otp', { email: trialEmail, productName });
       const data = resp.data;
-      if (data && data.ok) {
+      if (data && (data.ok === true || data.ok === 'true')) {
         setTrialStage('otp');
         setTrialOtp('');
         setTrialOtpExpiresAt(Date.now() + 5 * 60 * 1000);
         toast({ title: 'OTP sent', description: 'Please check your email and enter the 6-digit OTP (expires in 5 minutes).' });
       } else {
-        toast({ title: 'Failed to send OTP', description: String(data?.message || data?.error || 'Unknown error') });
+        const msg = data?.message || data?.error || JSON.stringify(data);
+        toast({ title: 'Failed to send OTP', description: String(msg) });
       }
     } catch (err: any) {
       console.error('Send OTP error', err);

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -1,6 +1,7 @@
 import { useParams, useNavigate } from "react-router-dom";
 import { Check } from "lucide-react";
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 const products = [
   { slug: "mylapay-tokenx", name: "TokenX", fullName: "Mylapay TokenX" },
@@ -30,6 +31,7 @@ const products = [
 export default function ProductPricing() {
   const { productSlug } = useParams<{ productSlug: string }>();
   const navigate = useNavigate();
+  const navigateToCompare = useNavigate();
   const [billingCycle, setBillingCycle] = useState<"yearly" | "monthly">(
     "yearly",
   );
@@ -124,12 +126,12 @@ export default function ProductPricing() {
               <button className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium transition-colors group-hover:bg-white group-hover:text-[#052343]">
                 Try Now
               </button>
-              <a
-                href="#"
-                className="text-center text-xs text-gray-600 underline mt-2 block group-hover:text-gray-100"
+              <button
+                onClick={() => navigateToCompare(`/pricing/${productSlug}/compare`)}
+                className="text-center text-xs text-gray-600 underline mt-2 block group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3]"
               >
                 See more
-              </a>
+              </button>
             </div>
           </div>
 
@@ -169,12 +171,12 @@ export default function ProductPricing() {
               <button className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium transition-colors group-hover:bg-white group-hover:text-[#052343]">
                 Buy Now
               </button>
-              <a
-                href="#"
-                className="text-center text-xs text-gray-600 underline mt-2 block group-hover:text-gray-100"
+              <button
+                onClick={() => navigateToCompare(`/pricing/${productSlug}/compare`)}
+                className="text-center text-xs text-gray-600 underline mt-2 block group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3]"
               >
                 See more
-              </a>
+              </button>
             </div>
           </div>
 
@@ -223,12 +225,12 @@ export default function ProductPricing() {
               <button className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium transition-colors group-hover:bg-white group-hover:text-[#052343]">
                 Buy Now
               </button>
-              <a
-                href="#"
-                className="text-center text-xs text-gray-600 underline mt-2 block group-hover:text-gray-100"
+              <button
+                onClick={() => navigateToCompare(`/pricing/${productSlug}/compare`)}
+                className="text-center text-xs text-gray-600 underline mt-2 block group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3]"
               >
                 See more
-              </a>
+              </button>
             </div>
           </div>
 
@@ -280,12 +282,12 @@ export default function ProductPricing() {
               <button className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium transition-colors group-hover:bg-white group-hover:text-[#052343]">
                 Contact Now
               </button>
-              <a
-                href="#"
-                className="text-center text-xs text-gray-600 underline mt-2 block group-hover:text-gray-100"
+              <button
+                onClick={() => navigateToCompare(`/pricing/${productSlug}/compare`)}
+                className="text-center text-xs text-gray-600 underline mt-2 block group-hover:text-gray-100 cursor-pointer hover:text-[#2CADE3]"
               >
                 See more
-              </a>
+              </button>
             </div>
           </div>
         </div>

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -94,180 +94,197 @@ export default function ProductPricing() {
         {/* Pricing Cards */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 items-stretch">
           {/* Trial Plan */}
-          <div className="bg-white rounded-2xl shadow-xl p-6 md:p-8 flex flex-col min-h-[16rem]">
-            <div className="text-center mb-6">
-              <h3 className="text-2xl font-semibold mb-2">Trial</h3>
-              <p className="text-[#2CADE3] text-lg mb-3">Free (up to 7 days)</p>
-              <p className="text-xs text-gray-600">
-                Best for initial evaluation and integration testing
-              </p>
-            </div>
+          <div className="relative overflow-hidden group bg-white rounded-2xl shadow-xl p-6 md:p-8 flex flex-col min-h-[16rem]">
+            <div className="absolute inset-0 bg-gradient-to-b from-[#2CADE3] to-[#052343] opacity-0 transition-opacity duration-300 group-hover:opacity-100"></div>
 
-            <div className="space-y-3 mb-6 flex-grow">
-              <div className="flex items-start gap-2">
-                <Check className="w-5 h-5 text-gray-800 flex-shrink-0 mt-0.5" />
-                <span className="text-xs text-gray-600">
-                  Upto 100 transactions per day
-                </span>
+            <div className="relative z-10 text-gray-900 group-hover:text-white">
+              <div className="text-center mb-6">
+                <h3 className="text-2xl font-semibold mb-2">Trial</h3>
+                <p className="text-[#2CADE3] text-lg mb-3 group-hover:text-white">Free (up to 7 days)</p>
+                <p className="text-xs text-gray-600 group-hover:text-gray-100">
+                  Best for initial evaluation and integration testing
+                </p>
               </div>
-              <div className="flex items-start gap-2">
-                <Check className="w-5 h-5 text-gray-800 flex-shrink-0 mt-0.5" />
-                <span className="text-xs text-gray-600">Email support</span>
-              </div>
-            </div>
 
-            <button className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium hover:bg-[#2399c9] transition-colors">
-              Try Now
-            </button>
-            <a
-              href="#"
-              className="text-center text-xs text-gray-600 underline mt-2 block"
-            >
-              See more
-            </a>
+              <div className="space-y-3 mb-6 flex-grow">
+                <div className="flex items-start gap-2">
+                  <Check className="w-5 h-5 text-gray-800 group-hover:text-white flex-shrink-0 mt-0.5" />
+                  <span className="text-xs text-gray-600 group-hover:text-gray-100">
+                    Upto 100 transactions per day
+                  </span>
+                </div>
+                <div className="flex items-start gap-2">
+                  <Check className="w-5 h-5 text-gray-800 group-hover:text-white flex-shrink-0 mt-0.5" />
+                  <span className="text-xs text-gray-600 group-hover:text-gray-100">Email support</span>
+                </div>
+              </div>
+
+              <button className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium transition-colors group-hover:bg-white group-hover:text-[#052343]">
+                Try Now
+              </button>
+              <a
+                href="#"
+                className="text-center text-xs text-gray-600 underline mt-2 block group-hover:text-gray-100"
+              >
+                See more
+              </a>
+            </div>
           </div>
 
           {/* Basic Plan */}
-          <div className="bg-white rounded-2xl shadow-xl p-6 md:p-8 flex flex-col min-h-[20rem]">
-            <div className="text-center mb-6">
-              <h3 className="text-2xl font-semibold mb-2">Basic Plan</h3>
-              <p className="text-gray-600 text-lg mb-3">$$$$/ Year</p>
-              <p className="text-xs text-gray-600">
-                Ideal for small to mid-size merchants starting transaction
-                processing
-              </p>
-            </div>
+          <div className="relative overflow-hidden group bg-white rounded-2xl shadow-xl p-6 md:p-8 flex flex-col min-h-[20rem]">
+            <div className="absolute inset-0 bg-gradient-to-b from-[#2CADE3] to-[#052343] opacity-0 transition-opacity duration-300 group-hover:opacity-100"></div>
 
-            <div className="space-y-3 mb-6 flex-grow">
-              <div className="flex items-start gap-2">
-                <Check className="w-5 h-5 text-gray-800 flex-shrink-0 mt-0.5" />
-                <span className="text-xs text-gray-600">
-                  Upto 500 transactions per day
-                </span>
+            <div className="relative z-10 text-gray-900 group-hover:text-white">
+              <div className="text-center mb-6">
+                <h3 className="text-2xl font-semibold mb-2">Basic Plan</h3>
+                <p className="text-gray-600 text-lg mb-3 group-hover:text-white">$$$$/ Year</p>
+                <p className="text-xs text-gray-600 group-hover:text-gray-100">
+                  Ideal for small to mid-size merchants starting transaction
+                  processing
+                </p>
               </div>
-              <div className="flex items-start gap-2">
-                <Check className="w-5 h-5 text-gray-800 flex-shrink-0 mt-0.5" />
-                <span className="text-xs text-gray-600">
-                  Standard monthly transaction limit
-                </span>
-              </div>
-              <div className="flex items-start gap-2">
-                <Check className="w-5 h-5 text-gray-800 flex-shrink-0 mt-0.5" />
-                <span className="text-xs text-gray-600">Standard support</span>
-              </div>
-            </div>
 
-            <button className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium hover:bg-[#2399c9] transition-colors">
-              Buy Now
-            </button>
-            <a
-              href="#"
-              className="text-center text-xs text-gray-600 underline mt-2 block"
-            >
-              See more
-            </a>
+              <div className="space-y-3 mb-6 flex-grow">
+                <div className="flex items-start gap-2">
+                  <Check className="w-5 h-5 text-gray-800 group-hover:text-white flex-shrink-0 mt-0.5" />
+                  <span className="text-xs text-gray-600 group-hover:text-gray-100">
+                    Upto 500 transactions per day
+                  </span>
+                </div>
+                <div className="flex items-start gap-2">
+                  <Check className="w-5 h-5 text-gray-800 group-hover:text-white flex-shrink-0 mt-0.5" />
+                  <span className="text-xs text-gray-600 group-hover:text-gray-100">
+                    Standard monthly transaction limit
+                  </span>
+                </div>
+                <div className="flex items-start gap-2">
+                  <Check className="w-5 h-5 text-gray-800 group-hover:text-white flex-shrink-0 mt-0.5" />
+                  <span className="text-xs text-gray-600 group-hover:text-gray-100">Standard support</span>
+                </div>
+              </div>
+
+              <button className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium transition-colors group-hover:bg-white group-hover:text-[#052343]">
+                Buy Now
+              </button>
+              <a
+                href="#"
+                className="text-center text-xs text-gray-600 underline mt-2 block group-hover:text-gray-100"
+              >
+                See more
+              </a>
+            </div>
           </div>
 
           {/* Pro Plan - Best Seller */}
-          <div className="bg-white rounded-2xl shadow-xl p-6 md:p-8 flex flex-col min-h-[24rem] relative">
-            <div className="absolute top-2 right-2 bg-[#FFCD38] px-3 py-1 rounded text-xs font-medium">
+          <div className="relative overflow-hidden group bg-white rounded-2xl shadow-xl p-6 md:p-8 flex flex-col min-h-[24rem]">
+            <div className="absolute top-2 right-2 bg-[#FFCD38] px-3 py-1 rounded text-xs font-medium z-20">
               Best Seller
             </div>
-            <div className="text-center mb-6">
-              <h3 className="text-2xl font-semibold mb-2">Pro Plan</h3>
-              <p className="text-lg mb-3">$$$/ Year</p>
-              <p className="text-xs text-gray-600">
-                For growing merchants needing higher throughput and stability
-              </p>
-            </div>
 
-            <div className="space-y-3 mb-6 flex-grow">
-              <div className="flex items-start gap-2">
-                <Check className="w-5 h-5 flex-shrink-0 mt-0.5" />
-                <span className="text-sm">1,000+ transactions per day</span>
-              </div>
-              <div className="flex items-start gap-2">
-                <Check className="w-5 h-5 flex-shrink-0 mt-0.5" />
-                <span className="text-sm">Reduced per-transaction rate</span>
-              </div>
-              <div className="flex items-start gap-2">
-                <Check className="w-5 h-5 flex-shrink-0 mt-0.5" />
-                <span className="text-sm">High transaction limits</span>
-              </div>
-              <div className="flex items-start gap-2">
-                <Check className="w-5 h-5 flex-shrink-0 mt-0.5" />
-                <span className="text-sm">Priority support</span>
-              </div>
-              <div className="flex items-start gap-2">
-                <Check className="w-5 h-5 flex-shrink-0 mt-0.5" />
-                <span className="text-sm">
-                  Access to Value-Added Services (VAS)
-                </span>
-              </div>
-            </div>
+            <div className="absolute inset-0 bg-gradient-to-b from-[#2CADE3] to-[#052343] opacity-0 transition-opacity duration-300 group-hover:opacity-100"></div>
 
-            <button className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium hover:bg-[#2399c9] transition-colors">
-              Buy Now
-            </button>
-            <a
-              href="#"
-              className="text-center text-xs text-gray-600 underline mt-2 block"
-            >
-              See more
-            </a>
+            <div className="relative z-10 text-gray-900 group-hover:text-white">
+              <div className="text-center mb-6">
+                <h3 className="text-2xl font-semibold mb-2">Pro Plan</h3>
+                <p className="text-lg mb-3 group-hover:text-white">$$$/ Year</p>
+                <p className="text-xs text-gray-600 group-hover:text-gray-100">
+                  For growing merchants needing higher throughput and stability
+                </p>
+              </div>
+
+              <div className="space-y-3 mb-6 flex-grow">
+                <div className="flex items-start gap-2">
+                  <Check className="w-5 h-5 text-gray-800 group-hover:text-white flex-shrink-0 mt-0.5" />
+                  <span className="text-sm group-hover:text-gray-100">1,000+ transactions per day</span>
+                </div>
+                <div className="flex items-start gap-2">
+                  <Check className="w-5 h-5 text-gray-800 group-hover:text-white flex-shrink-0 mt-0.5" />
+                  <span className="text-sm group-hover:text-gray-100">Reduced per-transaction rate</span>
+                </div>
+                <div className="flex items-start gap-2">
+                  <Check className="w-5 h-5 text-gray-800 group-hover:text-white flex-shrink-0 mt-0.5" />
+                  <span className="text-sm group-hover:text-gray-100">High transaction limits</span>
+                </div>
+                <div className="flex items-start gap-2">
+                  <Check className="w-5 h-5 text-gray-800 group-hover:text-white flex-shrink-0 mt-0.5" />
+                  <span className="text-sm group-hover:text-gray-100">Priority support</span>
+                </div>
+                <div className="flex items-start gap-2">
+                  <Check className="w-5 h-5 text-gray-800 group-hover:text-white flex-shrink-0 mt-0.5" />
+                  <span className="text-sm group-hover:text-gray-100">
+                    Access to Value-Added Services (VAS)
+                  </span>
+                </div>
+              </div>
+
+              <button className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium transition-colors group-hover:bg-white group-hover:text-[#052343]">
+                Buy Now
+              </button>
+              <a
+                href="#"
+                className="text-center text-xs text-gray-600 underline mt-2 block group-hover:text-gray-100"
+              >
+                See more
+              </a>
+            </div>
           </div>
 
           {/* Enterprise Plan */}
-          <div className="bg-white rounded-2xl shadow-xl p-6 md:p-8 flex flex-col min-h-[28rem]">
-            <div className="text-center mb-6">
-              <h3 className="text-2xl font-semibold mb-2">Enterprise Plan</h3>
-              <p className="text-sm text-gray-600 mb-4">
-                For large-scale merchants requiring dedicated infrastructure
-              </p>
-            </div>
+          <div className="relative overflow-hidden group bg-white rounded-2xl shadow-xl p-6 md:p-8 flex flex-col min-h-[28rem]">
+            <div className="absolute inset-0 bg-gradient-to-b from-[#2CADE3] to-[#052343] opacity-0 transition-opacity duration-300 group-hover:opacity-100"></div>
 
-            <div className="space-y-3 mb-6 flex-grow">
-              <div className="flex items-start gap-2">
-                <Check className="w-5 h-5 text-gray-800 flex-shrink-0 mt-0.5" />
-                <span className="text-xs text-gray-600">
-                  5,000+ transactions per day
-                </span>
+            <div className="relative z-10 text-gray-900 group-hover:text-white">
+              <div className="text-center mb-6">
+                <h3 className="text-2xl font-semibold mb-2">Enterprise Plan</h3>
+                <p className="text-sm text-gray-600 mb-4 group-hover:text-gray-100">
+                  For large-scale merchants requiring dedicated infrastructure
+                </p>
               </div>
-              <div className="flex items-start gap-2">
-                <Check className="w-5 h-5 text-gray-800 flex-shrink-0 mt-0.5" />
-                <span className="text-xs text-gray-600">
-                  Unlimited transactions
-                </span>
-              </div>
-              <div className="flex items-start gap-2">
-                <Check className="w-5 h-5 text-gray-800 flex-shrink-0 mt-0.5" />
-                <span className="text-xs text-gray-600">
-                  Volume-based pricing
-                </span>
-              </div>
-              <div className="flex items-start gap-2">
-                <Check className="w-5 h-5 text-gray-800 flex-shrink-0 mt-0.5" />
-                <span className="text-xs text-gray-600">
-                  24×7 dedicated support
-                </span>
-              </div>
-              <div className="flex items-start gap-2">
-                <Check className="w-5 h-5 text-gray-800 flex-shrink-0 mt-0.5" />
-                <span className="text-xs text-gray-600">
-                  Client-side deployment options
-                </span>
-              </div>
-            </div>
 
-            <button className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium hover:bg-[#2399c9] transition-colors">
-              Contact Now
-            </button>
-            <a
-              href="#"
-              className="text-center text-xs text-gray-600 underline mt-2 block"
-            >
-              See more
-            </a>
+              <div className="space-y-3 mb-6 flex-grow">
+                <div className="flex items-start gap-2">
+                  <Check className="w-5 h-5 text-gray-800 group-hover:text-white flex-shrink-0 mt-0.5" />
+                  <span className="text-xs text-gray-600 group-hover:text-gray-100">
+                    5,000+ transactions per day
+                  </span>
+                </div>
+                <div className="flex items-start gap-2">
+                  <Check className="w-5 h-5 text-gray-800 group-hover:text-white flex-shrink-0 mt-0.5" />
+                  <span className="text-xs text-gray-600 group-hover:text-gray-100">
+                    Unlimited transactions
+                  </span>
+                </div>
+                <div className="flex items-start gap-2">
+                  <Check className="w-5 h-5 text-gray-800 group-hover:text-white flex-shrink-0 mt-0.5" />
+                  <span className="text-xs text-gray-600 group-hover:text-gray-100">
+                    Volume-based pricing
+                  </span>
+                </div>
+                <div className="flex items-start gap-2">
+                  <Check className="w-5 h-5 text-gray-800 group-hover:text-white flex-shrink-0 mt-0.5" />
+                  <span className="text-xs text-gray-600 group-hover:text-gray-100">
+                    24×7 dedicated support
+                  </span>
+                </div>
+                <div className="flex items-start gap-2">
+                  <Check className="w-5 h-5 text-gray-800 group-hover:text-white flex-shrink-0 mt-0.5" />
+                  <span className="text-xs text-gray-600 group-hover:text-gray-100">
+                    Client-side deployment options
+                  </span>
+                </div>
+              </div>
+
+              <button className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium transition-colors group-hover:bg-white group-hover:text-[#052343]">
+                Contact Now
+              </button>
+              <a
+                href="#"
+                className="text-center text-xs text-gray-600 underline mt-2 block group-hover:text-gray-100"
+              >
+                See more
+              </a>
+            </div>
           </div>
         </div>
       </div>

--- a/server/index.ts
+++ b/server/index.ts
@@ -168,8 +168,9 @@ app.post("/api/log-user", (req: Request, res: Response) => {
 
       res.json({ ok: true, order: response.data, keyId });
     } catch (err: any) {
-      console.error("Razorpay create order error:", err?.response?.data || err.message || err);
-      res.status(500).json({ ok: false, error: err?.response?.data || err.message });
+      const errData = err?.response?.data || err?.message || String(err);
+      console.error("Razorpay create order error:", errData);
+      res.status(500).json({ ok: false, error: errData });
     }
   });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -216,16 +216,17 @@ export function createServer(): Express {
   });
 
   // --- Server proxy for Mylapay OTP (avoids CORS and exposes sandbox endpoint via our server) ---
-  app.post('/api/mylapay/require-otp', async (req: Request, res: Response) => {
-    const axios = await import('axios');
-    const externalUrl = 'https://apisandbox-nonprod.mylapay.com/mylapay/v1/mylapay_site/require-otp';
+  app.post("/api/mylapay/require-otp", async (req: Request, res: Response) => {
+    const axios = await import("axios");
+    const externalUrl =
+      "https://apisandbox-nonprod.mylapay.com/mylapay/v1/mylapay_site/require-otp";
     const maxRetries = 2;
     const timeoutMs = 5000;
 
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
       try {
         const resp = await axios.default.post(externalUrl, req.body, {
-          headers: { 'Content-Type': 'application/json' },
+          headers: { "Content-Type": "application/json" },
           timeout: timeoutMs,
         });
         // forward success response
@@ -233,7 +234,10 @@ export function createServer(): Express {
       } catch (err: any) {
         const status = err?.response?.status;
         const data = err?.response?.data;
-        console.error(`Mylapay require-otp proxy attempt ${attempt} error:`, { status, data: data || err?.message || String(err) });
+        console.error(`Mylapay require-otp proxy attempt ${attempt} error:`, {
+          status,
+          data: data || err?.message || String(err),
+        });
 
         // If server error (5xx), retry (unless last attempt)
         if (status && status >= 500 && attempt < maxRetries) {
@@ -248,7 +252,9 @@ export function createServer(): Express {
     }
 
     // Should not reach here, but fallback
-    return res.status(502).json({ ok: false, error: { message: 'Upstream service unavailable' } });
+    return res
+      .status(502)
+      .json({ ok: false, error: { message: "Upstream service unavailable" } });
   });
 
   // --- Automatic visitor log ---

--- a/server/index.ts
+++ b/server/index.ts
@@ -173,17 +173,14 @@ app.post("/api/log-user", (req: Request, res: Response) => {
     }
   });
 
-  app.post("/api/razorpay/verify", (req: Request, res: Response) => {
+  app.post("/api/razorpay/verify", async (req: Request, res: Response) => {
     try {
       const { razorpay_order_id, razorpay_payment_id, razorpay_signature } = req.body;
       const keySecret = process.env.RAZORPAY_KEY_SECRET;
       if (!keySecret) return res.status(500).json({ ok: false, error: "Missing key secret" });
 
-      const crypto = require("crypto");
-      const expected = crypto
-        .createHmac("sha256", keySecret)
-        .update(razorpay_order_id + "|" + razorpay_payment_id)
-        .digest("hex");
+      const crypto = await import("crypto");
+      const expected = crypto.createHmac("sha256", keySecret).update(razorpay_order_id + "|" + razorpay_payment_id).digest("hex");
 
       if (expected === razorpay_signature) {
         return res.json({ ok: true });

--- a/server/index.ts
+++ b/server/index.ts
@@ -166,7 +166,7 @@ app.post("/api/log-user", (req: Request, res: Response) => {
         { auth: { username: keyId, password: keySecret } },
       );
 
-      res.json({ ok: true, order: response.data });
+      res.json({ ok: true, order: response.data, keyId });
     } catch (err: any) {
       console.error("Razorpay create order error:", err?.response?.data || err.message || err);
       res.status(500).json({ ok: false, error: err?.response?.data || err.message });

--- a/server/index.ts
+++ b/server/index.ts
@@ -215,6 +215,20 @@ export function createServer(): Express {
     }
   });
 
+  // --- Server proxy for Mylapay OTP (avoids CORS and exposes sandbox endpoint via our server) ---
+  app.post('/api/mylapay/require-otp', async (req: Request, res: Response) => {
+    try {
+      const axios = await import('axios');
+      const externalUrl = 'https://apisandbox-nonprod.mylapay.com/mylapay/v1/mylapay_site/require-otp';
+      const resp = await axios.default.post(externalUrl, req.body, { headers: { 'Content-Type': 'application/json' } });
+      return res.json(resp.data);
+    } catch (err: any) {
+      console.error('Mylapay require-otp proxy error:', err?.response?.data || err?.message || err);
+      const errData = err?.response?.data || { message: err?.message || String(err) };
+      return res.status(err?.response?.status || 500).json({ ok: false, error: errData });
+    }
+  });
+
   // --- Automatic visitor log ---
   app.get("/api/track-visitor", (_req: Request, res: Response) => {
     try {

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4258,5 +4258,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T14:08:42.367Z"
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T14:09:09.598Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4030,5 +4030,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_op3unhfy",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T13:51:01.559Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3394,5 +3394,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_d973fs1h",
+    "duration": 8,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T12:20:15.128Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3946,5 +3946,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_el5illex",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T13:47:54.836Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3970,5 +3970,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T13:48:42.414Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4222,5 +4222,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_4wp93cns",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T14:08:18.587Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3442,5 +3442,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T12:23:51.167Z"
+  },
+  {
+    "sessionId": "sess_kujin4xh",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T12:24:02.638Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -2962,5 +2962,77 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-tokenx/compare",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T11:56:24.528Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T11:56:49.906Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-cswitch",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T11:56:58.246Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-intellesettle",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T11:57:08.159Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T11:58:29.231Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-intellesettle",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T11:58:40.982Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3262,5 +3262,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T12:10:43.307Z"
+  },
+  {
+    "page": "/pricing/mylapay-intellesettle",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T12:11:09.289Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -2482,5 +2482,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T11:28:52.931Z"
+  },
+  {
+    "sessionId": "sess_a9dyqjb2",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T11:29:02.317Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4234,5 +4234,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T14:08:18.587Z"
+  },
+  {
+    "sessionId": "sess_goc0o04t",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T14:08:36.062Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -2902,5 +2902,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T11:53:07.188Z"
+  },
+  {
+    "page": "/pricing/mylapay-tokenx/compare",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T11:53:12.277Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -2614,5 +2614,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T11:36:36.849Z"
+  },
+  {
+    "sessionId": "sess_bujccg7g",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T11:38:04.611Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4366,5 +4366,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_ynbwkuy1",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T14:12:49.035Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -2494,5 +2494,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T11:29:02.317Z"
+  },
+  {
+    "sessionId": "sess_48ruqosg",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T11:30:09.168Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3286,5 +3286,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T12:11:16.705Z"
+  },
+  {
+    "page": "/pricing/mylapay-intellesettle",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T12:12:24.411Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3250,5 +3250,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_4vc6c668",
+    "duration": 2,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T12:10:43.307Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -2506,5 +2506,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T11:30:09.168Z"
+  },
+  {
+    "sessionId": "sess_bjgpa2d2",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T11:31:03.791Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -2446,5 +2446,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_ty3lfz0u",
+    "duration": 3,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T11:24:48.069Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -2914,5 +2914,29 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_fm5dbkz3",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T11:53:49.282Z"
+  },
+  {
+    "page": "/pricing/mylapay-tokenx/compare",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T11:54:03.982Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3406,5 +3406,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T12:20:15.128Z"
+  },
+  {
+    "sessionId": "sess_rhjwsrwo",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T12:20:37.060Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4402,5 +4402,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T14:13:31.772Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4318,5 +4318,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T14:11:14.110Z"
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T14:11:28.721Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -2674,5 +2674,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T11:44:32.375Z"
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T11:45:10.326Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3238,5 +3238,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-intellesettle",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T12:09:12.118Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3154,5 +3154,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_0r54zjbz",
+    "duration": 6,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T12:07:47.856Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3850,5 +3850,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T13:45:07.098Z"
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T13:45:26.331Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -2458,5 +2458,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T11:24:48.069Z"
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T11:26:10.263Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3874,5 +3874,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_jbssyg1h",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T13:46:08.882Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3826,5 +3826,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T13:43:55.352Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -2566,5 +2566,29 @@
       "ll": null
     },
     "timestamp": "2025-11-21T11:34:37.147Z"
+  },
+  {
+    "sessionId": "sess_ewk3wca2",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T11:34:52.066Z"
+  },
+  {
+    "sessionId": "sess_sq1gx3g0",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T11:35:20.035Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3430,5 +3430,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_9rv7k9u3",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T12:23:51.167Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3778,5 +3778,41 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T13:42:52.307Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-secure",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T13:43:19.675Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-secure",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T13:43:26.436Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3070,5 +3070,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T11:59:28.276Z"
+  },
+  {
+    "page": "/pricing/mylapay-intellesettle",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T12:01:00.087Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3898,5 +3898,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T13:46:27.911Z"
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T13:46:45.482Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4126,5 +4126,53 @@
       "ll": null
     },
     "timestamp": "2025-11-21T13:54:38.192Z"
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T13:55:10.803Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T13:55:38.324Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-secure",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T14:02:12.567Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-uswitch",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T14:02:22.921Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3670,5 +3670,29 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_6bd8hve5",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T13:40:27.279Z"
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T13:40:32.443Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -2314,5 +2314,137 @@
       "ll": null
     },
     "timestamp": "2025-11-21T10:07:32.109Z"
+  },
+  {
+    "page": "/",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T10:40:00.574Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T10:40:11.860Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T10:40:49.871Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "sessionId": "sess_krzadn3m",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T10:40:58.043Z"
+  },
+  {
+    "page": "/",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T10:58:49.680Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T10:59:24.335Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T11:00:15.882Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T11:11:53.312Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T11:16:42.396Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T11:21:37.646Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T11:21:46.126Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4282,5 +4282,29 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_bexrpzyf",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T14:09:32.152Z"
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T14:10:13.610Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3982,5 +3982,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T13:49:56.916Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -2830,5 +2830,65 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_sy684m48",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T11:50:25.229Z"
+  },
+  {
+    "page": "/pricing/mylapay-tokenx/compare",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T11:50:36.895Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "sessionId": "sess_bop5dk9u",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T11:50:52.847Z"
+  },
+  {
+    "page": "/",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T11:51:07.920Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-tokenx/compare",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T11:51:14.047Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3226,5 +3226,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-secure",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T12:09:06.581Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3862,5 +3862,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T13:45:32.072Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4006,5 +4006,29 @@
       "ll": null
     },
     "timestamp": "2025-11-21T13:50:04.242Z"
+  },
+  {
+    "sessionId": "sess_6zc7yi6p",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T13:50:20.237Z"
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T13:50:44.369Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4102,5 +4102,29 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_6vf74gi4",
+    "duration": 2,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T13:53:32.644Z"
+  },
+  {
+    "sessionId": "sess_chascoob",
+    "duration": 2,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T13:54:38.192Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3922,5 +3922,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T13:46:50.526Z"
+  },
+  {
+    "sessionId": "sess_l94uyzbw",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T13:47:12.223Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4246,5 +4246,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T14:08:36.062Z"
+  },
+  {
+    "sessionId": "sess_stno6jg0",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T14:08:42.367Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3694,5 +3694,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_ibhp9mzf",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T13:40:41.721Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -2530,5 +2530,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T11:31:16.259Z"
+  },
+  {
+    "sessionId": "sess_c0zuep12",
+    "duration": 2,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T11:33:01.477Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3274,5 +3274,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_fwhzv3z1",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T12:11:16.705Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3754,5 +3754,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_baul215i",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T13:41:47.848Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -2554,5 +2554,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T11:33:33.160Z"
+  },
+  {
+    "sessionId": "sess_jc2wh07t",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T11:34:37.147Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3298,5 +3298,101 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-secure/compare",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T12:12:33.816Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-secure",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T12:12:40.300Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T12:12:53.232Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-intellesettle/compare",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T12:15:39.200Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-intellesettle",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T12:15:45.604Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-intellesettle/compare",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T12:16:42.681Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-intellesettle/compare",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T12:16:55.672Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-intellesettle",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T12:18:34.956Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3658,5 +3658,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T13:40:00.738Z"
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T13:40:07.462Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3646,5 +3646,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T13:39:50.254Z"
+  },
+  {
+    "sessionId": "sess_f2ybn5ij",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T13:40:00.738Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -2518,5 +2518,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T11:31:03.791Z"
+  },
+  {
+    "sessionId": "sess_51e0p3w2",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T11:31:16.259Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3742,5 +3742,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T13:41:40.777Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3838,5 +3838,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_zr60hp69",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T13:45:07.098Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3178,5 +3178,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_sgpy26qy",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T12:08:02.518Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -2590,5 +2590,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T11:35:20.035Z"
+  },
+  {
+    "sessionId": "sess_yhw244pl",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T11:36:25.530Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3418,5 +3418,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T12:20:37.060Z"
+  },
+  {
+    "page": "/pricing/mylapay-intellesettle",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T12:22:39.442Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4330,5 +4330,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_i2rle7hf",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T14:11:36.824Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3622,5 +3622,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_p795cadt",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T13:39:42.272Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4174,5 +4174,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_6joi64xa",
+    "duration": 13,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T14:07:51.473Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4342,5 +4342,29 @@
       "ll": null
     },
     "timestamp": "2025-11-21T14:11:36.824Z"
+  },
+  {
+    "sessionId": "sess_4qw2psq8",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T14:11:42.438Z"
+  },
+  {
+    "page": "/pricing/mylapay-uswitch",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T14:12:18.777Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4042,5 +4042,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T13:51:01.559Z"
+  },
+  {
+    "sessionId": "sess_m3xcfshp",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T13:51:25.979Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3094,5 +3094,65 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_1w09lrcy",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T12:01:41.005Z"
+  },
+  {
+    "page": "/pricing/mylapay-tokenx/compare",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T12:03:14.308Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-secure",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T12:04:08.508Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-secure/compare",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T12:05:22.353Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-secure",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T12:05:36.403Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3634,5 +3634,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T13:39:42.272Z"
+  },
+  {
+    "sessionId": "sess_aewto6f1",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T13:39:50.254Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -2806,5 +2806,29 @@
       "ll": null
     },
     "timestamp": "2025-11-21T11:49:29.108Z"
+  },
+  {
+    "sessionId": "sess_52i0jnie",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T11:49:50.795Z"
+  },
+  {
+    "page": "/pricing/mylapay-tokenx/compare",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T11:50:11.144Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4186,5 +4186,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T14:07:51.473Z"
+  },
+  {
+    "sessionId": "sess_02uiqd40",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T14:07:57.085Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3706,5 +3706,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T13:40:41.721Z"
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T13:41:16.439Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3202,5 +3202,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T12:08:17.238Z"
+  },
+  {
+    "page": "/pricing/mylapay-intellesettle",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T12:08:29.187Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3910,5 +3910,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_wthtyaip",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T13:46:50.526Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4210,5 +4210,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T14:08:02.569Z"
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T14:08:07.981Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3598,5 +3598,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T13:39:20.686Z"
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T13:39:27.074Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3046,5 +3046,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T11:59:10.988Z"
+  },
+  {
+    "page": "/pricing/mylapay-intellesettle",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T11:59:16.985Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -2662,5 +2662,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T11:42:36.096Z"
+  },
+  {
+    "sessionId": "sess_qywmsmhs",
+    "duration": 2,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T11:44:32.375Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3214,5 +3214,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-intellesettle",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T12:08:53.756Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -2938,5 +2938,29 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_7eks1po7",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T11:54:17.188Z"
+  },
+  {
+    "page": "/pricing/mylapay-tokenx/compare",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T11:54:28.017Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3766,5 +3766,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T13:41:47.848Z"
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T13:42:46.625Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4378,5 +4378,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T14:12:49.035Z"
+  },
+  {
+    "sessionId": "sess_2tbq9hhv",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T14:13:06.264Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4390,5 +4390,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T14:13:06.264Z"
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T14:13:11.855Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3082,5 +3082,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-intellesettle",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T12:01:07.281Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3574,5 +3574,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_1e5gy5sj",
+    "duration": 11,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T13:38:31.596Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3814,5 +3814,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T13:43:33.274Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -2602,5 +2602,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T11:36:25.530Z"
+  },
+  {
+    "sessionId": "sess_7hrlxowc",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T11:36:36.849Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3958,5 +3958,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T13:47:54.836Z"
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T13:48:35.045Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3934,5 +3934,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T13:47:12.223Z"
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T13:47:49.636Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3166,5 +3166,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T12:07:47.856Z"
+  },
+  {
+    "page": "/pricing/mylapay-intellesettle",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T12:07:54.496Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3718,5 +3718,29 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T13:41:30.210Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T13:41:35.504Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -2626,5 +2626,29 @@
       "ll": null
     },
     "timestamp": "2025-11-21T11:38:04.611Z"
+  },
+  {
+    "sessionId": "sess_no51ux1i",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T11:39:23.185Z"
+  },
+  {
+    "page": "/pricing/mylapay-cswitch",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T11:39:47.560Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4054,5 +4054,53 @@
       "ll": null
     },
     "timestamp": "2025-11-21T13:51:25.979Z"
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T13:51:40.640Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T13:51:51.139Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T13:51:57.963Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-tokenx/compare",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T13:52:27.577Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3886,5 +3886,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T13:46:08.882Z"
+  },
+  {
+    "sessionId": "sess_sptco8h6",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T13:46:27.911Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -2650,5 +2650,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_kq2quxip",
+    "duration": 3,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T11:42:36.096Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3586,5 +3586,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T13:38:31.596Z"
+  },
+  {
+    "sessionId": "sess_cwo65f4c",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T13:39:20.686Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3994,5 +3994,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_h6sdywkb",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T13:50:04.242Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3454,5 +3454,125 @@
       "ll": null
     },
     "timestamp": "2025-11-21T12:24:02.638Z"
+  },
+  {
+    "page": "/pricing/mylapay-intellesettle",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T12:24:27.564Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "sessionId": "sess_0i34xdb5",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T12:24:58.203Z"
+  },
+  {
+    "sessionId": "sess_hgtghedo",
+    "duration": 2,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T12:27:23.541Z"
+  },
+  {
+    "sessionId": "sess_ephnp09a",
+    "duration": 15,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T12:42:01.261Z"
+  },
+  {
+    "page": "/pricing/mylapay-intellesettle",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T12:42:42.941Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "sessionId": "sess_htao1wy6",
+    "duration": 5,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T12:47:25.056Z"
+  },
+  {
+    "page": "/",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T13:27:35.313Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T13:27:52.860Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T13:28:02.061Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T13:34:10.915Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4270,5 +4270,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-21T14:09:15.905Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3034,5 +3034,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_rqhxr2rs",
+    "duration": 3,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T11:59:10.988Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3058,5 +3058,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_i65r9qq6",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T11:59:28.276Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -2470,5 +2470,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_o0ojx4p8",
+    "duration": 3,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T11:28:52.931Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4198,5 +4198,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T14:07:57.085Z"
+  },
+  {
+    "sessionId": "sess_o0pcoilp",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T14:08:02.569Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3190,5 +3190,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T12:08:02.518Z"
+  },
+  {
+    "sessionId": "sess_pvc7em49",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T12:08:17.238Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -3610,5 +3610,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T13:39:33.601Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -2686,5 +2686,125 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-tokenx/compare",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T11:45:19.945Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-cswitch/compare",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T11:45:39.259Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T11:45:47.960Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-tokenx/compare",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T11:45:59.611Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "sessionId": "sess_wth32vxv",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T11:46:42.753Z"
+  },
+  {
+    "sessionId": "sess_rfixioya",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T11:46:49.004Z"
+  },
+  {
+    "sessionId": "sess_roq9k5c0",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T11:47:34.165Z"
+  },
+  {
+    "page": "/pricing/mylapay-tokenx/compare",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-21T11:47:41.366Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "sessionId": "sess_ws4odkxe",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T11:49:05.933Z"
+  },
+  {
+    "sessionId": "sess_lz0p4d1c",
+    "duration": 2,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T11:49:29.108Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -2542,5 +2542,17 @@
       "ll": null
     },
     "timestamp": "2025-11-21T11:33:01.477Z"
+  },
+  {
+    "sessionId": "sess_jv28iewh",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T11:33:33.160Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4306,5 +4306,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_5vdv7f1s",
+    "duration": 16,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T14:11:14.110Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -2890,5 +2890,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_rnyksyby",
+    "duration": 2,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-21T11:53:07.188Z"
   }
 ]


### PR DESCRIPTION
### Purpose

Based on user feedback regarding difficulties and runtime errors on the pricing page, this pull request introduces a new plan comparison page to improve user experience and clarity. The goal is to provide users with a clear and easy-to-understand comparison of the available pricing plans for each product.

### Code changes

- **New Route:** Added a new route in `client/App.tsx` for the plan comparison page at `/pricing/:productSlug/compare`.
- **New Component:** Created a new `PlanComparison.tsx` component under `client/pages/pricing/`.
- **Component Features:**
    - Fetches and displays product information based on the URL slug.
    - Includes a "Back to products" button for easy navigation.
    - Implements a toggle to switch between "Yearly" and "Monthly" billing cycles, with a "Save 15%" incentive for yearly plans.
    - Presents a structured layout to compare different plans: "Trial", "$25/Month", "$40/Month", and "Enterprise".
    - Contains an expandable FAQ section to answer common user questions.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/02ba57ec714e4b51bd04b1cb7b8bf390/glow-nest)

👀 [Preview Link](https://02ba57ec714e4b51bd04b1cb7b8bf390-glow-nest.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>02ba57ec714e4b51bd04b1cb7b8bf390</projectId>-->
<!--<branchName>glow-nest</branchName>-->