### PR TITLE
feat: Make footer full-width on pricing and home pages

### DIFF
--- a/client/components/layout/Footer.tsx
+++ b/client/components/layout/Footer.tsx
@@ -18,8 +18,8 @@ export default function Footer() {
 
   const gmailUrl = `https://mail.google.com/mail/?view=cm&fs=1&to=${email}`;
   return (
-    <footer className="bg-[#202c5c] text-white">
-      <div className="container mx-auto py-14">
+    <footer className="bg-[#202c5c] text-white pt-12">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-14">
         <div className="grid grid-cols-1 md:grid-cols-12 gap-10">
           {/* Logo + Copy */}
           <div className="md:col-span-3">

--- a/client/components/layout/Footer.tsx
+++ b/client/components/layout/Footer.tsx
@@ -23,7 +23,7 @@ export default function Footer() {
     <footer className="bg-[#202c5c] text-white pt-12">
       {/* Outer wrapper: full-bleed on homepage/pricing, or centered padded on other pages */}
       <div className={isFullWidth ? "w-full py-14" : "max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-14"}>
-        <div className={isFullWidth ? "max-w-7xl mx-auto px-4 sm:px-6 lg:px-8" : ""}>
+        <div className={isFullWidth ? "container mx-auto" : ""}>
           <div className="grid grid-cols-1 md:grid-cols-12 gap-10">
           {/* Logo + Copy */}
           <div className="md:col-span-3">

--- a/client/components/layout/Footer.tsx
+++ b/client/components/layout/Footer.tsx
@@ -21,9 +21,10 @@ export default function Footer() {
 
   return (
     <footer className="bg-[#202c5c] text-white pt-12">
-      {/* Use full-width 'container' on homepage and pricing pages, padded max-w on other pages */}
-      <div className={isFullWidth ? "container mx-auto py-14" : "max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-14"}>
-        <div className="grid grid-cols-1 md:grid-cols-12 gap-10">
+      {/* Outer wrapper: full-bleed on homepage/pricing, or centered padded on other pages */}
+      <div className={isFullWidth ? "w-full py-14" : "max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-14"}>
+        <div className={isFullWidth ? "max-w-7xl mx-auto px-4 sm:px-6 lg:px-8" : ""}>
+          <div className="grid grid-cols-1 md:grid-cols-12 gap-10">
           {/* Logo + Copy */}
           <div className="md:col-span-3">
             <div className="flex items-center gap-3">
@@ -285,6 +286,7 @@ export default function Footer() {
           </div>
           <div className="text-slate-500">
             © {new Date().getFullYear()} Mylapay. All rights reserved.
+          </div>
           </div>
         </div>
       </div>

--- a/client/components/layout/Footer.tsx
+++ b/client/components/layout/Footer.tsx
@@ -17,10 +17,12 @@ export default function Footer() {
   // const body = encodeURIComponent("I want to contact you.");
 
   const gmailUrl = `https://mail.google.com/mail/?view=cm&fs=1&to=${email}`;
+  const isFullWidth = location.pathname === "/" || location.pathname.startsWith("/pricing");
+
   return (
     <footer className="bg-[#202c5c] text-white pt-12">
-      {/* Use full-width 'container' on homepage, padded max-w on other pages */}
-      <div className={location.pathname === "/" ? "container mx-auto py-14" : "max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-14"}>
+      {/* Use full-width 'container' on homepage and pricing pages, padded max-w on other pages */}
+      <div className={isFullWidth ? "container mx-auto py-14" : "max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-14"}>
         <div className="grid grid-cols-1 md:grid-cols-12 gap-10">
           {/* Logo + Copy */}
           <div className="md:col-span-3">

--- a/client/components/layout/Footer.tsx
+++ b/client/components/layout/Footer.tsx
@@ -17,276 +17,307 @@ export default function Footer() {
   // const body = encodeURIComponent("I want to contact you.");
 
   const gmailUrl = `https://mail.google.com/mail/?view=cm&fs=1&to=${email}`;
-  const isFullWidth = location.pathname === "/" || location.pathname.startsWith("/pricing");
+  const isFullWidth =
+    location.pathname === "/" || location.pathname.startsWith("/pricing");
 
   return (
     <footer className="bg-[#202c5c] text-white pt-12">
       {/* Outer wrapper: full-bleed on homepage/pricing, or centered padded on other pages */}
-      <div className={isFullWidth ? "w-full py-14" : "max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-14"}>
+      <div
+        className={
+          isFullWidth
+            ? "w-full py-14"
+            : "max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-14"
+        }
+      >
         <div className={isFullWidth ? "container mx-auto" : ""}>
           <div className="grid grid-cols-1 md:grid-cols-12 gap-10">
-          {/* Logo + Copy */}
-          <div className="md:col-span-3">
-            <div className="flex items-center gap-3">
-              <img src={Favicon} alt="Mylapay" className="h-10 w-auto bg-white rounded " />
-              {/* <span className="font-semibold text-lg"></span> */}
+            {/* Logo + Copy */}
+            <div className="md:col-span-3">
+              <div className="flex items-center gap-3">
+                <img
+                  src={Favicon}
+                  alt="Mylapay"
+                  className="h-10 w-auto bg-white rounded "
+                />
+                {/* <span className="font-semibold text-lg"></span> */}
+              </div>
+
+              <p className="mt-4 text-sm text-slate-400 leading-relaxed">
+                Copyright © {new Date().getFullYear()} Mylapay.com
+              </p>
+              <p className="mt-2 text-xs text-slate-500 leading-relaxed">
+                For grievance resolution, contact our Grievance Officer at{" "}
+                <a
+                  // href="mailto:grievance@mylapay.com"
+                  className=" transition-colors"
+                >
+                  grievance@mylapay.com
+                </a>
+                .
+              </p>
             </div>
 
-            <p className="mt-4 text-sm text-slate-400 leading-relaxed">
-              Copyright © {new Date().getFullYear()} Mylapay.com
-            </p>
-            <p className="mt-2 text-xs text-slate-500 leading-relaxed">
-              For grievance resolution, contact our Grievance Officer at{" "}
-              <a
-                // href="mailto:grievance@mylapay.com"
-                className=" transition-colors"
-              >
-                grievance@mylapay.com
-              </a>
-              .
-            </p>
-          </div>
+            {/* Links */}
+            <div className="md:col-span-6 grid grid-cols-3 sm:grid-cols-3 gap-6">
+              <div>
+                <h4 className="text-sm font-semibold mb-3 text-slate-200">
+                  Resources
+                </h4>
+                <ul className="space-y-2">
+                  <li>
+                    <Link to="/casestudy" className={isActive("/casestudy")}>
+                      Case Study
+                    </Link>
+                  </li>
+                  <li>
+                    <Link to="/blog" className={isActive("/blog")}>
+                      Blog
+                    </Link>
+                  </li>
+                  <li>
+                    <Link to="/faq" className={isActive("/faq")}>
+                      FAQ
+                    </Link>
+                  </li>
+                  <li>
+                    <Link to="/about" className={isActive("/about")}>
+                      About Us
+                    </Link>
+                  </li>
+                  <li>
+                    <Link to="/careers" className={isActive("/careers")}>
+                      Careers
+                    </Link>
+                  </li>
+                  <li>
+                    <Link to="/contact" className={isActive("/contact")}>
+                      Contact
+                    </Link>
+                  </li>
+                </ul>
+              </div>
 
-          {/* Links */}
-          <div className="md:col-span-6 grid grid-cols-3 sm:grid-cols-3 gap-6">
-            <div>
+              <div>
+                <h4 className="text-sm font-semibold mb-3 text-slate-200">
+                  Products
+                </h4>
+                <ul className="space-y-2">
+                  <li>
+                    <Link
+                      to="/products/mylapay-tokenx"
+                      className={isActive("/products/mylapay-tokenx")}
+                    >
+                      Mylapay TokenX
+                    </Link>
+                  </li>
+                  <li>
+                    <Link
+                      to="/products/mylapay-secure"
+                      className={isActive("/products/mylapay-secure")}
+                    >
+                      Mylapay Secure
+                    </Link>
+                  </li>
+                  <li>
+                    <Link
+                      to="/products/mylapay-cswitch"
+                      className={isActive("/products/mylapay-cswitch")}
+                    >
+                      Mylapay C Switch
+                    </Link>
+                  </li>
+                  <li>
+                    <Link
+                      to="/products/mylapay-intellewatch"
+                      className={isActive("/products/mylapay-intellewatch")}
+                    >
+                      Intelle Watch
+                    </Link>
+                  </li>
+                  <li>
+                    <Link
+                      to="/products/mylapay-intellesettle"
+                      className={isActive("/products/mylapay-intellesettle")}
+                    >
+                      IntelleSettle
+                    </Link>
+                  </li>
+                  <li>
+                    <Link
+                      to="/products/mylapay-intellesolve"
+                      className={isActive("/products/mylapay-intellesolve")}
+                    >
+                      IntelleSolve
+                    </Link>
+                  </li>
+                  <li>
+                    <Link
+                      to="/products/mylapay-intelle360"
+                      className={isActive("/products/mylapay-intelle360")}
+                    >
+                      Intelle360
+                    </Link>
+                  </li>
+                  <li>
+                    <Link
+                      to="/products/mylapay-uswitch"
+                      className={isActive("/products/mylapay-uswitch")}
+                    >
+                      Mylapay U Switch
+                    </Link>
+                  </li>
+                  <li>
+                    <Link
+                      to="/products/mylapay-intellepro"
+                      className={isActive("/products/mylapay-intellepro")}
+                    >
+                      IntellePro
+                    </Link>
+                  </li>
+                  <li>
+                    <Link
+                      to="/products/mylapay-switchx"
+                      className={isActive("/products/mylapay-switchx")}
+                    >
+                      Mylapay SwitchX
+                    </Link>
+                  </li>
+                </ul>
+              </div>
+
+              <div>
+                <h4 className="text-sm font-semibold mb-3 text-slate-200">
+                  Solutions
+                </h4>
+                <ul className="space-y-2">
+                  <li>
+                    <Link
+                      to="/solutions/acquiring"
+                      className={isActive("//solutions/acquiring")}
+                    >
+                      Acquiring Support
+                    </Link>
+                  </li>
+                  <li>
+                    <Link
+                      to="/solutions/card-payments"
+                      className={isActive("/solutions/card-payments")}
+                    >
+                      Card Payments
+                    </Link>
+                  </li>
+                  <li>
+                    <Link
+                      to="/solutions/upi-payments"
+                      className={isActive("/solutions/upi-payments")}
+                    >
+                      UPI Payments
+                    </Link>
+                  </li>
+                  <li>
+                    <Link
+                      to="/solutions/payment-orchestration"
+                      className={isActive("/solutions/payment-orchestration")}
+                    >
+                      Payment Orchestration
+                    </Link>
+                  </li>
+                </ul>
+              </div>
+            </div>
+
+            {/* Location + Contact */}
+            <div className="md:col-span-3">
               <h4 className="text-sm font-semibold mb-3 text-slate-200">
-                Resources
+                Our Location
               </h4>
-              <ul className="space-y-2">
-                <li>
-                  <Link to="/casestudy" className={isActive("/casestudy")}>
-                    Case Study
-                  </Link>
-                </li>
-                <li>
-                  <Link to="/blog" className={isActive("/blog")}>
-                    Blog
-                  </Link>
-                </li>
-                <li>
-                  <Link to="/faq" className={isActive("/faq")}>
-                    FAQ
-                  </Link>
-                </li>
-                <li>
-                  <Link to="/about" className={isActive("/about")}>
-                    About Us
-                  </Link>
-                </li>
-                <li>
-                  <Link to="/careers" className={isActive("/careers")}>
-                    Careers
-                  </Link>
-                </li>
-                <li>
-                  <Link to="/contact" className={isActive("/contact")}>
-                    Contact
-                  </Link>
-                </li>
-              </ul>
-            </div>
-
-            
-                <div>
-              <h4 className="text-sm font-semibold mb-3 text-slate-200">
-                Products
-              </h4>
-              <ul className="space-y-2">
-                <li>
-                  <Link
-                    to="/products/mylapay-tokenx"
-                    className={isActive("/products/mylapay-tokenx")}
-                  >
-                    Mylapay TokenX
-                  </Link>
-                </li>
-                <li>
-                  
-                  <Link
-                    to="/products/mylapay-secure"
-                    className={isActive("/products/mylapay-secure")}
-                  >
-                    Mylapay Secure
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    to="/products/mylapay-cswitch"
-                    className={isActive("/products/mylapay-cswitch")}
-                  >
-                    Mylapay C Switch
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    to="/products/mylapay-intellewatch"
-                    className={isActive("/products/mylapay-intellewatch")}
-                  >
-                    Intelle Watch
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    to="/products/mylapay-intellesettle"
-                    className={isActive("/products/mylapay-intellesettle")}
-                  >
-                    IntelleSettle
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    to="/products/mylapay-intellesolve"
-                    className={isActive("/products/mylapay-intellesolve")}
-                  >
-                    IntelleSolve
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    to="/products/mylapay-intelle360"
-                    className={isActive("/products/mylapay-intelle360")}
-                  >
-                    Intelle360
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    to="/products/mylapay-uswitch"
-                    className={isActive("/products/mylapay-uswitch")}
-                  >
-                    Mylapay U Switch
-                  </Link>
-                </li>
-                 <li>
-                  <Link
-                    to="/products/mylapay-intellepro"
-                    className={isActive("/products/mylapay-intellepro")}
-                  >
-                    IntellePro
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    to="/products/mylapay-switchx"
-                    className={isActive("/products/mylapay-switchx")}
-                  >
-                    Mylapay SwitchX
-                  </Link>
-                </li>
-              </ul>
-            </div>
-
-            <div>
-              <h4 className="text-sm font-semibold mb-3 text-slate-200">
-                Solutions
-              </h4>
-              <ul className="space-y-2">
-                 <li>
-                  <Link to="/solutions/acquiring" className={isActive("//solutions/acquiring")}>
-                    Acquiring Support
-                  </Link>
-                </li>
-                <li>
-                  <Link to="/solutions/card-payments" className={isActive("/solutions/card-payments")}>
-                    Card Payments
-                  </Link>
-                </li>
-                <li>
-                  <Link to="/solutions/upi-payments" className={isActive("/solutions/upi-payments")}>
-                    UPI Payments
-                  </Link>
-                </li>
-                <li>
-                  <Link to = "/solutions/payment-orchestration" className={isActive("/solutions/payment-orchestration")}>
-                  Payment Orchestration</Link>
-                </li>
-              </ul>
-            </div>
-
-
-          </div>
-
-          {/* Location + Contact */}
-          <div className="md:col-span-3">
-            <h4 className="text-sm font-semibold mb-3 text-slate-200">
-              Our Location
-            </h4>
-            <h5 className="mb-2">Corporate Office</h5>
-            <a href="https://maps.app.goo.gl/w7hZ92HJsPeDaNLb8" target="_blank" rel="noopener noreferrer" className="hover:text-white ">
-              <p className="text-sm text-slate-400 leading-relaxed hover:text-white ">
-              No 17/3, (Old No 8C), 2nd Floor, Pembroke,
-              <br />
-              Shafee Mohammad Road, Nungambakkam,
-              <br />
-              Chennai, Tamil Nadu, India, 600006.
-            </p>
-            </a>
-            <h5 className="mb-2 mt-2">Business Center</h5>
-            <a  target="_blank" href="https://maps.app.goo.gl/mAbj2wYzi84eXRks9" rel="noopener noreferrer"  >
-              <p className="text-sm text-slate-400 leading-relaxed hover:text-white ">
-              202B, Pinnacle Corporate Park B Wing,
-              <br />
-              Second Floor, Bandra Kurla Complex, East, 
-              <br />
-              Mumbai, Maharashtra 400051.
-            </p>
-            </a>
-            
-
-            <div className="mt-2 text-sm text-slate-400">
+              <h5 className="mb-2">Corporate Office</h5>
               <a
-      href={gmailUrl}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="hover:text-white transition-colors block  "
-    >
-               contactus@mylapay.com
-              </a>
-              {/* <div className="mt-2">contactus@mylapay.com</div> */}
-              <div className="mt-2">+91 81222 28396</div>
-            </div>
-
-            {/* Social Links */}
-            <div className="mt-6 flex items-center gap-4">
-              <a
-                href="https://www.facebook.com/mylapay?mibextid=9R9pXO"
-                target="_blank" rel="noopener noreferrer"
-                className="p-2 rounded-full bg-slate-700/40 hover:bg-[#1877F2] transition-all duration-300 hover:scale-110"
+                href="https://maps.app.goo.gl/w7hZ92HJsPeDaNLb8"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:text-white "
               >
-                <Facebook className="h-5 w-5 text-slate-300 hover:text-white" />
+                <p className="text-sm text-slate-400 leading-relaxed hover:text-white ">
+                  No 17/3, (Old No 8C), 2nd Floor, Pembroke,
+                  <br />
+                  Shafee Mohammad Road, Nungambakkam,
+                  <br />
+                  Chennai, Tamil Nadu, India, 600006.
+                </p>
               </a>
+              <h5 className="mb-2 mt-2">Business Center</h5>
               <a
-                href="https://www.linkedin.com/company/mylapay/mycompany/"
-                target="_blank" rel="noopener noreferrer"
-                className="p-2 rounded-full bg-slate-700/40 hover:bg-[#0A66C2] transition-all duration-300 hover:scale-110"
+                target="_blank"
+                href="https://maps.app.goo.gl/mAbj2wYzi84eXRks9"
+                rel="noopener noreferrer"
               >
-                <Linkedin className="h-5 w-5 text-slate-300 hover:text-white" />
+                <p className="text-sm text-slate-400 leading-relaxed hover:text-white ">
+                  202B, Pinnacle Corporate Park B Wing,
+                  <br />
+                  Second Floor, Bandra Kurla Complex, East,
+                  <br />
+                  Mumbai, Maharashtra 400051.
+                </p>
               </a>
-              <a
-                href="https://www.youtube.com/@mylapay6480"
-                target="_blank" rel="noopener noreferrer"
-                className="p-2 rounded-full bg-slate-700/40 hover:bg-[#FF0000] transition-all duration-300 hover:scale-110"
-              >
-                <Youtube className="h-5 w-5 text-slate-300 hover:text-white" />
-              </a>
+
+              <div className="mt-2 text-sm text-slate-400">
+                <a
+                  href={gmailUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:text-white transition-colors block  "
+                >
+                  contactus@mylapay.com
+                </a>
+                {/* <div className="mt-2">contactus@mylapay.com</div> */}
+                <div className="mt-2">+91 81222 28396</div>
+              </div>
+
+              {/* Social Links */}
+              <div className="mt-6 flex items-center gap-4">
+                <a
+                  href="https://www.facebook.com/mylapay?mibextid=9R9pXO"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="p-2 rounded-full bg-slate-700/40 hover:bg-[#1877F2] transition-all duration-300 hover:scale-110"
+                >
+                  <Facebook className="h-5 w-5 text-slate-300 hover:text-white" />
+                </a>
+                <a
+                  href="https://www.linkedin.com/company/mylapay/mycompany/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="p-2 rounded-full bg-slate-700/40 hover:bg-[#0A66C2] transition-all duration-300 hover:scale-110"
+                >
+                  <Linkedin className="h-5 w-5 text-slate-300 hover:text-white" />
+                </a>
+                <a
+                  href="https://www.youtube.com/@mylapay6480"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="p-2 rounded-full bg-slate-700/40 hover:bg-[#FF0000] transition-all duration-300 hover:scale-110"
+                >
+                  <Youtube className="h-5 w-5 text-slate-300 hover:text-white" />
+                </a>
+              </div>
             </div>
           </div>
-        </div>
 
-        {/* Bottom bar */}
-        <div className="mt-10 flex flex-col md:flex-row items-center justify-between text-xs text-slate-500 border-t border-slate-700 pt-6">
-          <div className="flex gap-6 mb-2 md:mb-0">
-            <Link to="/terms" className={isActive("/terms")}>
-              Acceptance Policy
-            </Link>
-            <Link to="/privacy" className={isActive("/privacy")}>
-              Privacy
-            </Link>
-          </div>
-          <div className="text-slate-500">
-            © {new Date().getFullYear()} Mylapay. All rights reserved.
-          </div>
+          {/* Bottom bar */}
+          <div className="mt-10 flex flex-col md:flex-row items-center justify-between text-xs text-slate-500 border-t border-slate-700 pt-6">
+            <div className="flex gap-6 mb-2 md:mb-0">
+              <Link to="/terms" className={isActive("/terms")}>
+                Acceptance Policy
+              </Link>
+              <Link to="/privacy" className={isActive("/privacy")}>
+                Privacy
+              </Link>
+            </div>
+            <div className="text-slate-500">
+              © {new Date().getFullYear()} Mylapay. All rights reserved.
+            </div>
           </div>
         </div>
       </div>

--- a/client/components/layout/Footer.tsx
+++ b/client/components/layout/Footer.tsx
@@ -18,8 +18,9 @@ export default function Footer() {
 
   const gmailUrl = `https://mail.google.com/mail/?view=cm&fs=1&to=${email}`;
   return (
-    <footer className="bg-[#202c5c] text-white pt-12 pb-0">
-      <div className="max-w-7xl mx-auto">
+    <footer className="bg-[#202c5c] text-white pt-12">
+      {/* Use full-width 'container' on homepage, padded max-w on other pages */}
+      <div className={location.pathname === "/" ? "container mx-auto py-14" : "max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-14"}>
         <div className="grid grid-cols-1 md:grid-cols-12 gap-10">
           {/* Logo + Copy */}
           <div className="md:col-span-3">

--- a/client/components/layout/Footer.tsx
+++ b/client/components/layout/Footer.tsx
@@ -18,8 +18,8 @@ export default function Footer() {
 
   const gmailUrl = `https://mail.google.com/mail/?view=cm&fs=1&to=${email}`;
   return (
-    <footer className="bg-[#202c5c] text-white pt-12">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-14">
+    <footer className="bg-[#202c5c] text-white pt-12 pb-0">
+      <div className="max-w-7xl mx-auto">
         <div className="grid grid-cols-1 md:grid-cols-12 gap-10">
           {/* Logo + Copy */}
           <div className="md:col-span-3">

--- a/client/pages/Home/components/ProductsSection.tsx
+++ b/client/pages/Home/components/ProductsSection.tsx
@@ -1,518 +1,546 @@
 import ScrollScale from "@/components/ui/scroll-scale";
-import { Activity, BarChart3, Database, GitBranch, KeyRound, RotateCcw, Server, ShieldAlert, ShieldCheck, Zap } from "lucide-react";
-import {Link} from "react-router-dom"
+import {
+  Activity,
+  BarChart3,
+  Database,
+  GitBranch,
+  KeyRound,
+  RotateCcw,
+  Server,
+  ShieldAlert,
+  ShieldCheck,
+  Zap,
+} from "lucide-react";
+import { Link } from "react-router-dom";
 import { motion } from "framer-motion";
 
-
 export default function ProductsSection() {
-const text = "Mylapay Product Suites";
+  const text = "Mylapay Product Suites";
 
-    return(
-        <section
-        id="products"
-        className="bg-[#202c5c] scroll-mt-20 md:scroll-mt-24"
+  return (
+    <section
+      id="products"
+      className="bg-[#202c5c] scroll-mt-20 md:scroll-mt-24"
+    >
+      <ScrollScale
+        as="div"
+        className="container mx-auto py-12 md:py-16"
+        direction="right"
+        fromScale={0.55}
+        toScale={1}
+        fromOpacity={0.08}
+        toOpacity={1}
+        startViewportRatio={1.2}
+        endViewportRatio={0}
       >
-        <ScrollScale
-          as="div"
-          className="container mx-auto py-12 md:py-16"
-          direction="right"
-          fromScale={0.55}
-          toScale={1}
-          fromOpacity={0.08}
-          toOpacity={1}
-          startViewportRatio={1.2}
-          endViewportRatio={0}
-        >
-          <h2 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center text-white mb-10">
-            {text.split("").map((char, index) => (
-                    <motion.span
-                      key={index}
-                      className={char === " " ? "mx-1" : ""}
-                      animate={{
-                        y: [0, -10, 0],      // vertical movement
-                        opacity: [0, 1, 1],   // fade in, then hold
-                      }}
-                      transition={{
-                        duration: 1,          // animation time
-                        delay: index * 0.1,   // stagger letters
-                        repeat: Infinity,     // infinite loop
-                        repeatType: "loop",
-                        repeatDelay: 4        // pause before next loop
-                      }}
-                    >
-                      {char}
-                    </motion.span>
-                  ))}
-          </h2>
+        <h2 className="text-2xl md:text-3xl lg:text-4xl font-bold text-center text-white mb-10">
+          {text.split("").map((char, index) => (
+            <motion.span
+              key={index}
+              className={char === " " ? "mx-1" : ""}
+              animate={{
+                y: [0, -10, 0], // vertical movement
+                opacity: [0, 1, 1], // fade in, then hold
+              }}
+              transition={{
+                duration: 1, // animation time
+                delay: index * 0.1, // stagger letters
+                repeat: Infinity, // infinite loop
+                repeatType: "loop",
+                repeatDelay: 4, // pause before next loop
+              }}
+            >
+              {char}
+            </motion.span>
+          ))}
+        </h2>
 
-          <div className="max-w-6xl mx-auto">
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {/* 1 */}
-              <Link
-                className="rounded-lg border border-[#219dd2] bg-[#202c5c] p-6 text-white group relative overflow-hidden transform transition-all duration-300 hover:shadow-xl hover:-translate-y-1"
-                role="link"
-                tabIndex={0}
-                onClick={() => (window.location.href = "#")}
-                onKeyDown={(e) => {
-                  if ((e as any).key === "Enter") window.location.href = "#";
-                }}
-                style={{ cursor: "pointer" }}
-                to="/products/mylapay-tokenx"
+        <div className="max-w-6xl mx-auto">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {/* 1 */}
+            <Link
+              className="rounded-lg border border-[#219dd2] bg-[#202c5c] p-6 text-white group relative overflow-hidden transform transition-all duration-300 hover:shadow-xl hover:-translate-y-1"
+              role="link"
+              tabIndex={0}
+              onClick={() => (window.location.href = "#")}
+              onKeyDown={(e) => {
+                if ((e as any).key === "Enter") window.location.href = "#";
+              }}
+              style={{ cursor: "pointer" }}
+              to="/products/mylapay-tokenx"
+            >
+              {" "}
+              <div className="absolute inset-0 rounded-lg bg-gradient-to-br from-[#1b355f] to-[#219dd2] opacity-0 group-hover:opacity-80 transition-opacity duration-300 pointer-events-none"></div>
+              <div
+                className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center"
+                aria-hidden
               >
-                {" "}
-                <div className="absolute inset-0 rounded-lg bg-gradient-to-br from-[#1b355f] to-[#219dd2] opacity-0 group-hover:opacity-80 transition-opacity duration-300 pointer-events-none"></div>
-                <div className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center" aria-hidden>
-                  <svg
-                    className="h-5 w-5"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M12 19V6"
-                      stroke="currentColor"
-                      strokeWidth="1.8"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                    <path
-                      d="M5 12l7-7 7 7"
-                      stroke="currentColor"
-                      strokeWidth="1.8"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                </div>
-                <div className="flex flex-col items-start relative z-10">
-                  <KeyRound className="h-8 w-8 text-white mb-3" aria-hidden />
-
-                  <h3 className="text-lg font-semibold">Mylapay TokenX</h3>
-                  <p className="mt-1 text-sm text-white/90">
-                    Card Tokenization - COF & Alt ID
-                  </p>
-                  <p className="mt-2 text-xs text-[#219dd2] font-medium">
-                    Encrypt | Process | Tokenize
-                  </p>
-                </div>
-              </Link>
-
-              {/* 2 */}
-              <Link
-                className="rounded-lg border border-[#219dd2] bg-[#202c5c] p-6 text-white group relative overflow-hidden transform transition-all duration-300 hover:shadow-xl hover:-translate-y-1"
-                role="link"
-                to="/products/mylapay-secure"
-                tabIndex={0}
-                onClick={() => (window.location.href = "#")}
-                onKeyDown={(e) => {
-                  if ((e as any).key === "Enter") window.location.href = "#";
-                }}
-                style={{ cursor: "pointer" }}
-              >
-                {" "}
-                <div className="absolute inset-0 rounded-lg bg-gradient-to-br from-[#1b355f] to-[#219dd2] opacity-0 group-hover:opacity-80 transition-opacity duration-300 pointer-events-none"></div>
-                <div className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center" role="presentation">
-                  <svg
-                    className="h-5 w-5"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M12 19V6"
-                      stroke="currentColor"
-                      strokeWidth="1.8"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                    <path
-                      d="M5 12l7-7 7 7"
-                      stroke="currentColor"
-                      strokeWidth="1.8"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                </div>
-                <div className="flex flex-col items-start relative z-10">
-                  <ShieldCheck
-                    className="h-8 w-8 text-white mb-3"
-                    aria-hidden
+                <svg
+                  className="h-5 w-5"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 19V6"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
                   />
-
-                  <h3 className="text-lg font-semibold">Mylapay Secure</h3>
-                  <p className="mt-1 text-sm text-white/90">
-                    3DS Server certified by EMVCo
-                  </p>
-                  <p className="mt-2 text-xs text-[#219dd2] font-medium">
-                    Detect | Prevent | Authenticate
-                  </p>
-                </div>
-              </Link>
-
-              {/* 3 */}
-              <Link
-                className="rounded-lg border border-[#219dd2] bg-[#202c5c] p-6 text-white group relative overflow-hidden transform transition-all duration-300 hover:shadow-xl hover:-translate-y-1"
-                role="link"
-                to="/products/mylapay-cswitch"
-                tabIndex={0}
-                onClick={() => (window.location.href = "#")}
-                onKeyDown={(e) => {
-                  if ((e as any).key === "Enter") window.location.href = "#";
-                }}
-                style={{ cursor: "pointer" }}
-              >
-                {" "}
-                <div className="absolute inset-0 rounded-lg bg-gradient-to-br from-[#1b355f] to-[#219dd2] opacity-0 group-hover:opacity-80 transition-opacity duration-300 pointer-events-none"></div>
-                <div className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center" role="presentation">
-                  <svg
-                    className="h-5 w-5"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M12 19V6"
-                      stroke="currentColor"
-                      strokeWidth="1.8"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                    <path
-                      d="M5 12l7-7 7 7"
-                      stroke="currentColor"
-                      strokeWidth="1.8"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                </div>
-                <div className="flex flex-col items-start relative z-10">
-                  <Server className="h-8 w-8 text-white mb-3" aria-hidden />
-
-                  <h3 className="text-lg font-semibold">Mylapay C-Switch</h3>
-                  <p className="mt-1 text-sm text-white/90">
-                    Base I Auth Switch for Card Payments
-                  </p>
-                  <p className="mt-2 text-xs text-[#219dd2] font-medium">
-                    Integrate | Transact | Authorize
-                  </p>
-                </div>
-              </Link>
-
-              {/* 4 */}
-              <Link
-                className="rounded-lg border border-[#219dd2] bg-[#202c5c] p-6 text-white group relative overflow-hidden transform transition-all duration-300 hover:shadow-xl hover:-translate-y-1"
-                role="link"
-                to="/products/mylapay-intellewatch"
-                tabIndex={0}
-                onClick={() => (window.location.href = "#")}
-                onKeyDown={(e) => {
-                  if ((e as any).key === "Enter") window.location.href = "#";
-                }}
-                style={{ cursor: "pointer" }}
-              >
-                {" "}
-                <div className="absolute inset-0 rounded-lg bg-gradient-to-br from-[#1b355f] to-[#219dd2] opacity-0 group-hover:opacity-80 transition-opacity duration-300 pointer-events-none"></div>
-                <div className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center" role="presentation">
-                  <svg
-                    className="h-5 w-5"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M12 19V6"
-                      stroke="currentColor"
-                      strokeWidth="1.8"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                    <path
-                      d="M5 12l7-7 7 7"
-                      stroke="currentColor"
-                      strokeWidth="1.8"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                </div>
-                <div className="flex flex-col items-start relative z-10">
-                  <ShieldAlert
-                    className="h-8 w-8 text-white mb-3"
-                    aria-hidden
+                  <path
+                    d="M5 12l7-7 7 7"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
                   />
+                </svg>
+              </div>
+              <div className="flex flex-col items-start relative z-10">
+                <KeyRound className="h-8 w-8 text-white mb-3" aria-hidden />
 
-                  <h3 className="text-lg font-semibold">IntelleWatch</h3>
-                  <p className="mt-1 text-sm text-white/90">
-                    Fraud Risk Management (FRM) System
-                  </p>
-                  <p className="mt-2 text-xs text-[#219dd2] font-medium">
-                    Monitor | Block | Safeguard
-                  </p>
-                </div>
-              </Link>
+                <h3 className="text-lg font-semibold">Mylapay TokenX</h3>
+                <p className="mt-1 text-sm text-white/90">
+                  Card Tokenization - COF & Alt ID
+                </p>
+                <p className="mt-2 text-xs text-[#219dd2] font-medium">
+                  Encrypt | Process | Tokenize
+                </p>
+              </div>
+            </Link>
 
-              {/* 5 */}
-              <Link
-                className="rounded-lg border border-[#219dd2] bg-[#202c5c] p-6 text-white group relative overflow-hidden transform transition-all duration-300 hover:shadow-xl hover:-translate-y-1"
-                role="link"
-                to="/products/mylapay-intellesettle"
-                tabIndex={0}
-                onClick={() => (window.location.href = "#")}
-                onKeyDown={(e) => {
-                  if ((e as any).key === "Enter") window.location.href = "#";
-                }}
-                style={{ cursor: "pointer" }}
+            {/* 2 */}
+            <Link
+              className="rounded-lg border border-[#219dd2] bg-[#202c5c] p-6 text-white group relative overflow-hidden transform transition-all duration-300 hover:shadow-xl hover:-translate-y-1"
+              role="link"
+              to="/products/mylapay-secure"
+              tabIndex={0}
+              onClick={() => (window.location.href = "#")}
+              onKeyDown={(e) => {
+                if ((e as any).key === "Enter") window.location.href = "#";
+              }}
+              style={{ cursor: "pointer" }}
+            >
+              {" "}
+              <div className="absolute inset-0 rounded-lg bg-gradient-to-br from-[#1b355f] to-[#219dd2] opacity-0 group-hover:opacity-80 transition-opacity duration-300 pointer-events-none"></div>
+              <div
+                className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center"
+                role="presentation"
               >
-                {" "}
-                <div className="absolute inset-0 rounded-lg bg-gradient-to-br from-[#1b355f] to-[#219dd2] opacity-0 group-hover:opacity-80 transition-opacity duration-300 pointer-events-none"></div>
-                <div className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center" role="presentation">
-                  <svg
-                    className="h-5 w-5"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M12 19V6"
-                      stroke="currentColor"
-                      strokeWidth="1.8"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                    <path
-                      d="M5 12l7-7 7 7"
-                      stroke="currentColor"
-                      strokeWidth="1.8"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                </div>
-                <div className="flex flex-col items-start relative z-10">
-                  <Database className="h-8 w-8 text-white mb-3" aria-hidden />
+                <svg
+                  className="h-5 w-5"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 19V6"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M5 12l7-7 7 7"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </div>
+              <div className="flex flex-col items-start relative z-10">
+                <ShieldCheck className="h-8 w-8 text-white mb-3" aria-hidden />
 
-                  <h3 className="text-lg font-semibold">IntelleSettle</h3>
-                  <p className="mt-1 text-sm text-white/90">
-                    Base II Clearing & Settlement System
-                  </p>
-                  <p className="mt-2 text-xs text-[#219dd2] font-medium">
-                    Submit | Collect | Settle
-                  </p>
-                </div>
-              </Link>
+                <h3 className="text-lg font-semibold">Mylapay Secure</h3>
+                <p className="mt-1 text-sm text-white/90">
+                  3DS Server certified by EMVCo
+                </p>
+                <p className="mt-2 text-xs text-[#219dd2] font-medium">
+                  Detect | Prevent | Authenticate
+                </p>
+              </div>
+            </Link>
 
-              {/* 6 */}
-              <Link
-                className="rounded-lg border border-[#219dd2] bg-[#202c5c] p-6 text-white group relative overflow-hidden transform transition-all duration-300 hover:shadow-xl hover:-translate-y-1"
-                role="link"
-                to="/products/mylapay-intellesolve"
-                tabIndex={0}
-                onClick={() => (window.location.href = "#")}
-                onKeyDown={(e) => {
-                  if ((e as any).key === "Enter") window.location.href = "#";
-                }}
-                style={{ cursor: "pointer" }}
+            {/* 3 */}
+            <Link
+              className="rounded-lg border border-[#219dd2] bg-[#202c5c] p-6 text-white group relative overflow-hidden transform transition-all duration-300 hover:shadow-xl hover:-translate-y-1"
+              role="link"
+              to="/products/mylapay-cswitch"
+              tabIndex={0}
+              onClick={() => (window.location.href = "#")}
+              onKeyDown={(e) => {
+                if ((e as any).key === "Enter") window.location.href = "#";
+              }}
+              style={{ cursor: "pointer" }}
+            >
+              {" "}
+              <div className="absolute inset-0 rounded-lg bg-gradient-to-br from-[#1b355f] to-[#219dd2] opacity-0 group-hover:opacity-80 transition-opacity duration-300 pointer-events-none"></div>
+              <div
+                className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center"
+                role="presentation"
               >
-                {" "}
-                <div className="absolute inset-0 rounded-lg bg-gradient-to-br from-[#1b355f] to-[#219dd2] opacity-0 group-hover:opacity-80 transition-opacity duration-300 pointer-events-none"></div>
-                <div className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center" role="presentation">
-                  <svg
-                    className="h-5 w-5"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M12 19V6"
-                      stroke="currentColor"
-                      strokeWidth="1.8"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                    <path
-                      d="M5 12l7-7 7 7"
-                      stroke="currentColor"
-                      strokeWidth="1.8"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                </div>
-                <div className="flex flex-col items-start relative z-10">
-                  <RotateCcw className="h-8 w-8 text-white mb-3" aria-hidden />
+                <svg
+                  className="h-5 w-5"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 19V6"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M5 12l7-7 7 7"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </div>
+              <div className="flex flex-col items-start relative z-10">
+                <Server className="h-8 w-8 text-white mb-3" aria-hidden />
 
-                  <h3 className="text-lg font-semibold">IntelleSolve</h3>
-                  <p className="mt-1 text-sm text-white/90">
-                    Chargeback Management System
-                  </p>
-                  <p className="mt-2 text-xs text-[#219dd2] font-medium">
-                    Defend | Resolve | Recover
-                  </p>
-                </div>
-              </Link>
+                <h3 className="text-lg font-semibold">Mylapay C-Switch</h3>
+                <p className="mt-1 text-sm text-white/90">
+                  Base I Auth Switch for Card Payments
+                </p>
+                <p className="mt-2 text-xs text-[#219dd2] font-medium">
+                  Integrate | Transact | Authorize
+                </p>
+              </div>
+            </Link>
 
-              {/* 7 */}
-              <Link
-                className="rounded-lg border border-[#219dd2] bg-[#202c5c] p-6 text-white group relative overflow-hidden transform transition-all duration-300 hover:shadow-xl hover:-translate-y-1"
-                role="link"
-                to="/products/mylapay-intelle360"
-                tabIndex={0}
-                onClick={() => (window.location.href = "#")}
-                onKeyDown={(e) => {
-                  if ((e as any).key === "Enter") window.location.href = "#";
-                }}
-                style={{ cursor: "pointer" }}
+            {/* 4 */}
+            <Link
+              className="rounded-lg border border-[#219dd2] bg-[#202c5c] p-6 text-white group relative overflow-hidden transform transition-all duration-300 hover:shadow-xl hover:-translate-y-1"
+              role="link"
+              to="/products/mylapay-intellewatch"
+              tabIndex={0}
+              onClick={() => (window.location.href = "#")}
+              onKeyDown={(e) => {
+                if ((e as any).key === "Enter") window.location.href = "#";
+              }}
+              style={{ cursor: "pointer" }}
+            >
+              {" "}
+              <div className="absolute inset-0 rounded-lg bg-gradient-to-br from-[#1b355f] to-[#219dd2] opacity-0 group-hover:opacity-80 transition-opacity duration-300 pointer-events-none"></div>
+              <div
+                className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center"
+                role="presentation"
               >
-                {" "}
-                <div className="absolute inset-0 rounded-lg bg-gradient-to-br from-[#1b355f] to-[#219dd2] opacity-0 group-hover:opacity-80 transition-opacity duration-300 pointer-events-none"></div>
-                <div className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center" role="presentation">
-                  <svg
-                    className="h-5 w-5"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M12 19V6"
-                      stroke="currentColor"
-                      strokeWidth="1.8"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                    <path
-                      d="M5 12l7-7 7 7"
-                      stroke="currentColor"
-                      strokeWidth="1.8"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                </div>
-                <div className="flex flex-col items-start relative z-10">
-                  <BarChart3 className="h-8 w-8 text-white mb-3" aria-hidden />
+                <svg
+                  className="h-5 w-5"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 19V6"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M5 12l7-7 7 7"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </div>
+              <div className="flex flex-col items-start relative z-10">
+                <ShieldAlert className="h-8 w-8 text-white mb-3" aria-hidden />
 
-                  <h3 className="text-lg font-semibold">Intelle360</h3>
-                  <p className="mt-1 text-sm text-white/90">
-                    Analytics Suite for Acquiring Payments
-                  </p>
-                  <p className="mt-2 text-xs text-[#219dd2] font-medium">
-                    Intelligence | Protection | Growth
-                  </p>
-                </div>
-              </Link>
+                <h3 className="text-lg font-semibold">IntelleWatch</h3>
+                <p className="mt-1 text-sm text-white/90">
+                  Fraud Risk Management (FRM) System
+                </p>
+                <p className="mt-2 text-xs text-[#219dd2] font-medium">
+                  Monitor | Block | Safeguard
+                </p>
+              </div>
+            </Link>
 
-              {/* 8 */}
-              <Link
-                className="rounded-lg border border-[#219dd2] bg-[#202c5c] p-6 text-white group relative overflow-hidden transform transition-all duration-300 hover:shadow-xl hover:-translate-y-1"
-                role="link"
-                tabIndex={0}
-                to="/products/mylapay-uswitch"
-                onClick={() => (window.location.href = "#")}
-                onKeyDown={(e) => {
-                  if ((e as any).key === "Enter") window.location.href = "#";
-                }}
-                style={{ cursor: "pointer" }}
+            {/* 5 */}
+            <Link
+              className="rounded-lg border border-[#219dd2] bg-[#202c5c] p-6 text-white group relative overflow-hidden transform transition-all duration-300 hover:shadow-xl hover:-translate-y-1"
+              role="link"
+              to="/products/mylapay-intellesettle"
+              tabIndex={0}
+              onClick={() => (window.location.href = "#")}
+              onKeyDown={(e) => {
+                if ((e as any).key === "Enter") window.location.href = "#";
+              }}
+              style={{ cursor: "pointer" }}
+            >
+              {" "}
+              <div className="absolute inset-0 rounded-lg bg-gradient-to-br from-[#1b355f] to-[#219dd2] opacity-0 group-hover:opacity-80 transition-opacity duration-300 pointer-events-none"></div>
+              <div
+                className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center"
+                role="presentation"
               >
-                {" "}
-                <div className="absolute inset-0 rounded-lg bg-gradient-to-br from-[#1b355f] to-[#219dd2] opacity-0 group-hover:opacity-80 transition-opacity duration-300 pointer-events-none"></div>
-                <div className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center" role="presentation">
-                  <svg
-                    className="h-5 w-5"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M12 19V6"
-                      stroke="currentColor"
-                      strokeWidth="1.8"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                    <path
-                      d="M5 12l7-7 7 7"
-                      stroke="currentColor"
-                      strokeWidth="1.8"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                </div>
-                <div className="flex flex-col items-start relative z-10">
-                  <GitBranch className="h-8 w-8 text-white mb-3" aria-hidden />
+                <svg
+                  className="h-5 w-5"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 19V6"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M5 12l7-7 7 7"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </div>
+              <div className="flex flex-col items-start relative z-10">
+                <Database className="h-8 w-8 text-white mb-3" aria-hidden />
 
-                  <h3 className="text-lg font-semibold">Mylapay U-Switch</h3>
-                  <p className="mt-1 text-sm text-white/90">
-                    UPI Switch for PSPs, Beneficiary Banks
-                  </p>
-                  <p className="mt-2 text-xs text-[#219dd2] font-medium">
-                    Connect | Route | Approve
-                  </p>
-                </div>
-              </Link>
+                <h3 className="text-lg font-semibold">IntelleSettle</h3>
+                <p className="mt-1 text-sm text-white/90">
+                  Base II Clearing & Settlement System
+                </p>
+                <p className="mt-2 text-xs text-[#219dd2] font-medium">
+                  Submit | Collect | Settle
+                </p>
+              </div>
+            </Link>
 
-              {/* 9 */}
-              <Link
-                className="rounded-lg border border-[#219dd2] bg-[#202c5c] p-6 text-white group relative overflow-hidden transform transition-all duration-300 hover:shadow-xl hover:-translate-y-1"
-                role="link"
-                tabIndex={0}
-                to="/products/mylapay-intellepro"
-                onClick={() => (window.location.href = "#")}
-                onKeyDown={(e) => {
-                  if ((e as any).key === "Enter") window.location.href = "#";
-                }}
-                style={{ cursor: "pointer" }}
+            {/* 6 */}
+            <Link
+              className="rounded-lg border border-[#219dd2] bg-[#202c5c] p-6 text-white group relative overflow-hidden transform transition-all duration-300 hover:shadow-xl hover:-translate-y-1"
+              role="link"
+              to="/products/mylapay-intellesolve"
+              tabIndex={0}
+              onClick={() => (window.location.href = "#")}
+              onKeyDown={(e) => {
+                if ((e as any).key === "Enter") window.location.href = "#";
+              }}
+              style={{ cursor: "pointer" }}
+            >
+              {" "}
+              <div className="absolute inset-0 rounded-lg bg-gradient-to-br from-[#1b355f] to-[#219dd2] opacity-0 group-hover:opacity-80 transition-opacity duration-300 pointer-events-none"></div>
+              <div
+                className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center"
+                role="presentation"
               >
-                {" "}
-                <div className="absolute inset-0 rounded-lg bg-gradient-to-br from-[#1b355f] to-[#219dd2] opacity-0 group-hover:opacity-80 transition-opacity duration-300 pointer-events-none"></div>
-                <div className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center" role="presentation">
-                  <svg
-                    className="h-5 w-5"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M12 19V6"
-                      stroke="currentColor"
-                      strokeWidth="1.8"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                    <path
-                      d="M5 12l7-7 7 7"
-                      stroke="currentColor"
-                      strokeWidth="1.8"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                </div>
-                <div className="flex flex-col items-start relative z-10">
-                  <Activity className="h-8 w-8 text-white mb-3" aria-hidden />
+                <svg
+                  className="h-5 w-5"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 19V6"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M5 12l7-7 7 7"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </div>
+              <div className="flex flex-col items-start relative z-10">
+                <RotateCcw className="h-8 w-8 text-white mb-3" aria-hidden />
 
-                  <h3 className="text-lg font-semibold">IntellePro</h3>
-                  <p className="mt-1 text-sm text-white/90">
-                    Real-time TMS for UPI Transactions
-                  </p>
-                  <p className="mt-2 text-xs text-[#219dd2] font-medium">
-                    Reconcile | Settle | Recover
-                  </p>
-                </div>
-              </Link>
+                <h3 className="text-lg font-semibold">IntelleSolve</h3>
+                <p className="mt-1 text-sm text-white/90">
+                  Chargeback Management System
+                </p>
+                <p className="mt-2 text-xs text-[#219dd2] font-medium">
+                  Defend | Resolve | Recover
+                </p>
+              </div>
+            </Link>
 
+            {/* 7 */}
+            <Link
+              className="rounded-lg border border-[#219dd2] bg-[#202c5c] p-6 text-white group relative overflow-hidden transform transition-all duration-300 hover:shadow-xl hover:-translate-y-1"
+              role="link"
+              to="/products/mylapay-intelle360"
+              tabIndex={0}
+              onClick={() => (window.location.href = "#")}
+              onKeyDown={(e) => {
+                if ((e as any).key === "Enter") window.location.href = "#";
+              }}
+              style={{ cursor: "pointer" }}
+            >
+              {" "}
+              <div className="absolute inset-0 rounded-lg bg-gradient-to-br from-[#1b355f] to-[#219dd2] opacity-0 group-hover:opacity-80 transition-opacity duration-300 pointer-events-none"></div>
+              <div
+                className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center"
+                role="presentation"
+              >
+                <svg
+                  className="h-5 w-5"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 19V6"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M5 12l7-7 7 7"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </div>
+              <div className="flex flex-col items-start relative z-10">
+                <BarChart3 className="h-8 w-8 text-white mb-3" aria-hidden />
 
-            </div>
-              {/* 10 */}
-              <div >
-              <Link to="/products/mylapay-switchx">
+                <h3 className="text-lg font-semibold">Intelle360</h3>
+                <p className="mt-1 text-sm text-white/90">
+                  Analytics Suite for Acquiring Payments
+                </p>
+                <p className="mt-2 text-xs text-[#219dd2] font-medium">
+                  Intelligence | Protection | Growth
+                </p>
+              </div>
+            </Link>
+
+            {/* 8 */}
+            <Link
+              className="rounded-lg border border-[#219dd2] bg-[#202c5c] p-6 text-white group relative overflow-hidden transform transition-all duration-300 hover:shadow-xl hover:-translate-y-1"
+              role="link"
+              tabIndex={0}
+              to="/products/mylapay-uswitch"
+              onClick={() => (window.location.href = "#")}
+              onKeyDown={(e) => {
+                if ((e as any).key === "Enter") window.location.href = "#";
+              }}
+              style={{ cursor: "pointer" }}
+            >
+              {" "}
+              <div className="absolute inset-0 rounded-lg bg-gradient-to-br from-[#1b355f] to-[#219dd2] opacity-0 group-hover:opacity-80 transition-opacity duration-300 pointer-events-none"></div>
+              <div
+                className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center"
+                role="presentation"
+              >
+                <svg
+                  className="h-5 w-5"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 19V6"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M5 12l7-7 7 7"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </div>
+              <div className="flex flex-col items-start relative z-10">
+                <GitBranch className="h-8 w-8 text-white mb-3" aria-hidden />
+
+                <h3 className="text-lg font-semibold">Mylapay U-Switch</h3>
+                <p className="mt-1 text-sm text-white/90">
+                  UPI Switch for PSPs, Beneficiary Banks
+                </p>
+                <p className="mt-2 text-xs text-[#219dd2] font-medium">
+                  Connect | Route | Approve
+                </p>
+              </div>
+            </Link>
+
+            {/* 9 */}
+            <Link
+              className="rounded-lg border border-[#219dd2] bg-[#202c5c] p-6 text-white group relative overflow-hidden transform transition-all duration-300 hover:shadow-xl hover:-translate-y-1"
+              role="link"
+              tabIndex={0}
+              to="/products/mylapay-intellepro"
+              onClick={() => (window.location.href = "#")}
+              onKeyDown={(e) => {
+                if ((e as any).key === "Enter") window.location.href = "#";
+              }}
+              style={{ cursor: "pointer" }}
+            >
+              {" "}
+              <div className="absolute inset-0 rounded-lg bg-gradient-to-br from-[#1b355f] to-[#219dd2] opacity-0 group-hover:opacity-80 transition-opacity duration-300 pointer-events-none"></div>
+              <div
+                className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center"
+                role="presentation"
+              >
+                <svg
+                  className="h-5 w-5"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 19V6"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M5 12l7-7 7 7"
+                    stroke="currentColor"
+                    strokeWidth="1.8"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </div>
+              <div className="flex flex-col items-start relative z-10">
+                <Activity className="h-8 w-8 text-white mb-3" aria-hidden />
+
+                <h3 className="text-lg font-semibold">IntellePro</h3>
+                <p className="mt-1 text-sm text-white/90">
+                  Real-time TMS for UPI Transactions
+                </p>
+                <p className="mt-2 text-xs text-[#219dd2] font-medium">
+                  Reconcile | Settle | Recover
+                </p>
+              </div>
+            </Link>
+          </div>
+          {/* 10 */}
+          <div>
+            <Link to="/products/mylapay-switchx">
               <div
                 className="rounded-lg border border-[#219dd2] bg-[#202c5c] p-6 text-white group relative overflow-hidden transform transition-all duration-300 hover:shadow-xl hover:-translate-y-1 mt-6"
                 role="link"
                 tabIndex={0}
-                
                 onClick={() => (window.location.href = "#")}
                 onKeyDown={(e) => {
                   if ((e as any).key === "Enter") window.location.href = "#";
@@ -521,7 +549,10 @@ const text = "Mylapay Product Suites";
               >
                 {" "}
                 <div className="absolute inset-0 rounded-lg bg-gradient-to-br from-[#1b355f] to-[#219dd2] opacity-0 group-hover:opacity-80 transition-opacity duration-300 pointer-events-none"></div>
-                <div className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center" role="presentation">
+                <div
+                  className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center"
+                  role="presentation"
+                >
                   <svg
                     className="h-5 w-5"
                     viewBox="0 0 24 24"
@@ -549,17 +580,17 @@ const text = "Mylapay Product Suites";
 
                   <h3 className="text-lg font-semibold">Mylapay Switch X</h3>
                   <p className="mt-1 text-sm text-white/90">
-                   Payment Orchestration Hub
+                    Payment Orchestration Hub
                   </p>
                   <p className="mt-2 text-xs text-[#219dd2] font-medium">
                     Route | Integrate | Optimize
                   </p>
                 </div>
               </div>
-              </Link>
-              </div>
+            </Link>
           </div>
-        </ScrollScale>
-      </section>
-    );
+        </div>
+      </ScrollScale>
+    </section>
+  );
 }

--- a/client/pages/Home/components/ProductsSection.tsx
+++ b/client/pages/Home/components/ProductsSection.tsx
@@ -61,11 +61,7 @@ const text = "Mylapay Product Suites";
               >
                 {" "}
                 <div className="absolute inset-0 rounded-lg bg-gradient-to-br from-[#1b355f] to-[#219dd2] opacity-0 group-hover:opacity-80 transition-opacity duration-300 pointer-events-none"></div>
-                <Link
-                  to="/products/mylapay-tokenx"
-                  className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center"
-                  aria-hidden
-                >
+                <div className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center" aria-hidden>
                   <svg
                     className="h-5 w-5"
                     viewBox="0 0 24 24"
@@ -87,7 +83,7 @@ const text = "Mylapay Product Suites";
                       strokeLinejoin="round"
                     />
                   </svg>
-                </Link>
+                </div>
                 <div className="flex flex-col items-start relative z-10">
                   <KeyRound className="h-8 w-8 text-white mb-3" aria-hidden />
 
@@ -115,10 +111,7 @@ const text = "Mylapay Product Suites";
               >
                 {" "}
                 <div className="absolute inset-0 rounded-lg bg-gradient-to-br from-[#1b355f] to-[#219dd2] opacity-0 group-hover:opacity-80 transition-opacity duration-300 pointer-events-none"></div>
-                <a
-                  href="#"
-                  className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center"
-                >
+                <div className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center" role="presentation">
                   <svg
                     className="h-5 w-5"
                     viewBox="0 0 24 24"
@@ -140,7 +133,7 @@ const text = "Mylapay Product Suites";
                       strokeLinejoin="round"
                     />
                   </svg>
-                </a>
+                </div>
                 <div className="flex flex-col items-start relative z-10">
                   <ShieldCheck
                     className="h-8 w-8 text-white mb-3"
@@ -171,10 +164,7 @@ const text = "Mylapay Product Suites";
               >
                 {" "}
                 <div className="absolute inset-0 rounded-lg bg-gradient-to-br from-[#1b355f] to-[#219dd2] opacity-0 group-hover:opacity-80 transition-opacity duration-300 pointer-events-none"></div>
-                <a
-                  href="#"
-                  className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center"
-                >
+                <div className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center" role="presentation">
                   <svg
                     className="h-5 w-5"
                     viewBox="0 0 24 24"
@@ -196,7 +186,7 @@ const text = "Mylapay Product Suites";
                       strokeLinejoin="round"
                     />
                   </svg>
-                </a>
+                </div>
                 <div className="flex flex-col items-start relative z-10">
                   <Server className="h-8 w-8 text-white mb-3" aria-hidden />
 
@@ -224,10 +214,7 @@ const text = "Mylapay Product Suites";
               >
                 {" "}
                 <div className="absolute inset-0 rounded-lg bg-gradient-to-br from-[#1b355f] to-[#219dd2] opacity-0 group-hover:opacity-80 transition-opacity duration-300 pointer-events-none"></div>
-                <a
-                  href="#"
-                  className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center"
-                >
+                <div className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center" role="presentation">
                   <svg
                     className="h-5 w-5"
                     viewBox="0 0 24 24"
@@ -249,7 +236,7 @@ const text = "Mylapay Product Suites";
                       strokeLinejoin="round"
                     />
                   </svg>
-                </a>
+                </div>
                 <div className="flex flex-col items-start relative z-10">
                   <ShieldAlert
                     className="h-8 w-8 text-white mb-3"
@@ -280,10 +267,7 @@ const text = "Mylapay Product Suites";
               >
                 {" "}
                 <div className="absolute inset-0 rounded-lg bg-gradient-to-br from-[#1b355f] to-[#219dd2] opacity-0 group-hover:opacity-80 transition-opacity duration-300 pointer-events-none"></div>
-                <a
-                  href="#"
-                  className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center"
-                >
+                <div className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center" role="presentation">
                   <svg
                     className="h-5 w-5"
                     viewBox="0 0 24 24"
@@ -305,7 +289,7 @@ const text = "Mylapay Product Suites";
                       strokeLinejoin="round"
                     />
                   </svg>
-                </a>
+                </div>
                 <div className="flex flex-col items-start relative z-10">
                   <Database className="h-8 w-8 text-white mb-3" aria-hidden />
 
@@ -333,10 +317,7 @@ const text = "Mylapay Product Suites";
               >
                 {" "}
                 <div className="absolute inset-0 rounded-lg bg-gradient-to-br from-[#1b355f] to-[#219dd2] opacity-0 group-hover:opacity-80 transition-opacity duration-300 pointer-events-none"></div>
-                <a
-                  href="#"
-                  className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center"
-                >
+                <div className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center" role="presentation">
                   <svg
                     className="h-5 w-5"
                     viewBox="0 0 24 24"
@@ -358,7 +339,7 @@ const text = "Mylapay Product Suites";
                       strokeLinejoin="round"
                     />
                   </svg>
-                </a>
+                </div>
                 <div className="flex flex-col items-start relative z-10">
                   <RotateCcw className="h-8 w-8 text-white mb-3" aria-hidden />
 
@@ -386,10 +367,7 @@ const text = "Mylapay Product Suites";
               >
                 {" "}
                 <div className="absolute inset-0 rounded-lg bg-gradient-to-br from-[#1b355f] to-[#219dd2] opacity-0 group-hover:opacity-80 transition-opacity duration-300 pointer-events-none"></div>
-                <a
-                  href="#"
-                  className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center"
-                >
+                <div className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center" role="presentation">
                   <svg
                     className="h-5 w-5"
                     viewBox="0 0 24 24"
@@ -411,7 +389,7 @@ const text = "Mylapay Product Suites";
                       strokeLinejoin="round"
                     />
                   </svg>
-                </a>
+                </div>
                 <div className="flex flex-col items-start relative z-10">
                   <BarChart3 className="h-8 w-8 text-white mb-3" aria-hidden />
 
@@ -439,10 +417,7 @@ const text = "Mylapay Product Suites";
               >
                 {" "}
                 <div className="absolute inset-0 rounded-lg bg-gradient-to-br from-[#1b355f] to-[#219dd2] opacity-0 group-hover:opacity-80 transition-opacity duration-300 pointer-events-none"></div>
-                <a
-                  href="#"
-                  className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center"
-                >
+                <div className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center" role="presentation">
                   <svg
                     className="h-5 w-5"
                     viewBox="0 0 24 24"
@@ -464,7 +439,7 @@ const text = "Mylapay Product Suites";
                       strokeLinejoin="round"
                     />
                   </svg>
-                </a>
+                </div>
                 <div className="flex flex-col items-start relative z-10">
                   <GitBranch className="h-8 w-8 text-white mb-3" aria-hidden />
 
@@ -492,10 +467,7 @@ const text = "Mylapay Product Suites";
               >
                 {" "}
                 <div className="absolute inset-0 rounded-lg bg-gradient-to-br from-[#1b355f] to-[#219dd2] opacity-0 group-hover:opacity-80 transition-opacity duration-300 pointer-events-none"></div>
-                <a
-                  href="#"
-                  className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center"
-                >
+                <div className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center" role="presentation">
                   <svg
                     className="h-5 w-5"
                     viewBox="0 0 24 24"
@@ -517,7 +489,7 @@ const text = "Mylapay Product Suites";
                       strokeLinejoin="round"
                     />
                   </svg>
-                </a>
+                </div>
                 <div className="flex flex-col items-start relative z-10">
                   <Activity className="h-8 w-8 text-white mb-3" aria-hidden />
 
@@ -549,10 +521,7 @@ const text = "Mylapay Product Suites";
               >
                 {" "}
                 <div className="absolute inset-0 rounded-lg bg-gradient-to-br from-[#1b355f] to-[#219dd2] opacity-0 group-hover:opacity-80 transition-opacity duration-300 pointer-events-none"></div>
-                <a
-                  href="#"
-                  className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center"
-                >
+                <div className="absolute top-4 right-4 z-30 opacity-0 translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 transition-all text-[#219dd2] flex items-center justify-center" role="presentation">
                   <svg
                     className="h-5 w-5"
                     viewBox="0 0 24 24"
@@ -574,7 +543,7 @@ const text = "Mylapay Product Suites";
                       strokeLinejoin="round"
                     />
                   </svg>
-                </a>
+                </div>
                 <div className="flex flex-col items-center relative z-10">
                   <Zap className="h-8 w-8 text-white mb-3" aria-hidden />
 

--- a/client/pages/pricing/PlanComparison.tsx
+++ b/client/pages/pricing/PlanComparison.tsx
@@ -209,7 +209,7 @@ export default function PlanComparison() {
                 </h3>
                 <p className="text-xs text-gray-500 mb-6">/Month</p>
               </div>
-              <button className="w-full bg-[#2CADE3] text-white py-2 md:py-3 text-xs font-bold rounded hover:bg-[#2399c9] transition-colors">
+              <button onClick={() => navigate(`/pricing/${productSlug}?action=checkout&plan=basic`)} className="w-full bg-[#2CADE3] text-white py-2 md:py-3 text-xs font-bold rounded hover:bg-[#2399c9] transition-colors">
                 Choose This Plan
               </button>
             </div>
@@ -222,7 +222,7 @@ export default function PlanComparison() {
                 </h3>
                 <p className="text-xs text-gray-500 mb-6">/Month</p>
               </div>
-              <button className="w-full bg-[#2CADE3] text-white py-2 md:py-3 text-xs font-bold rounded hover:bg-[#2399c9] transition-colors">
+              <button onClick={() => navigate(`/pricing/${productSlug}?action=checkout&plan=pro`)} className="w-full bg-[#2CADE3] text-white py-2 md:py-3 text-xs font-bold rounded hover:bg-[#2399c9] transition-colors">
                 Choose This Plan
               </button>
             </div>
@@ -234,7 +234,7 @@ export default function PlanComparison() {
                   Custom
                 </h3>
               </div>
-              <button className="w-full bg-[#2CADE3] text-white py-2 md:py-3 text-xs font-bold rounded hover:bg-[#2399c9] transition-colors">
+              <button onClick={() => navigate('/contact')} className="w-full bg-[#2CADE3] text-white py-2 md:py-3 text-xs font-bold rounded hover:bg-[#2399c9] transition-colors">
                 Contact Now
               </button>
             </div>
@@ -416,6 +416,7 @@ export default function PlanComparison() {
           </div>
         </div>
       </div>
+      <Footer />
     </div>
   );
 }

--- a/client/pages/pricing/PlanComparison.tsx
+++ b/client/pages/pricing/PlanComparison.tsx
@@ -430,7 +430,7 @@ export default function PlanComparison() {
                 </h3>
                 <p className="text-xs text-gray-500 mb-6">/Month</p>
               </div>
-              <button onClick={() => navigate(`/pricing/${productSlug}?action=checkout&plan=basic&from=compare`)} className="w-full bg-[#2CADE3] text-white py-2 md:py-3 text-xs font-bold rounded hover:bg-[#2399c9] transition-colors">
+              <button onClick={() => openCheckoutFor("basic")} className="w-full bg-[#2CADE3] text-white py-2 md:py-3 text-xs font-bold rounded hover:bg-[#2399c9] transition-colors">
                 Choose This Plan
               </button>
             </div>

--- a/client/pages/pricing/PlanComparison.tsx
+++ b/client/pages/pricing/PlanComparison.tsx
@@ -1,4 +1,5 @@
 import { useParams, useNavigate } from "react-router-dom";
+import Footer from "@/components/layout/Footer";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { useState } from "react";
 

--- a/client/pages/pricing/PlanComparison.tsx
+++ b/client/pages/pricing/PlanComparison.tsx
@@ -196,7 +196,7 @@ export default function PlanComparison() {
                 </h3>
                 <p className="text-xs text-gray-500 mb-6">/Free (7 days)</p>
               </div>
-              <button className="w-full bg-[#2CADE3] text-white py-2 md:py-3 text-xs font-bold rounded hover:bg-[#2399c9] transition-colors">
+              <button onClick={() => navigate(`/pricing/${productSlug}?action=trial`)} className="w-full bg-[#2CADE3] text-white py-2 md:py-3 text-xs font-bold rounded hover:bg-[#2399c9] transition-colors">
                 Try now
               </button>
             </div>

--- a/client/pages/pricing/PlanComparison.tsx
+++ b/client/pages/pricing/PlanComparison.tsx
@@ -79,7 +79,9 @@ export default function PlanComparison() {
   const [trialEmail, setTrialEmail] = useState("");
   const [trialStage, setTrialStage] = useState<"email" | "otp">("email");
   const [trialOtp, setTrialOtp] = useState("");
-  const [trialOtpExpiresAt, setTrialOtpExpiresAt] = useState<number | null>(null);
+  const [trialOtpExpiresAt, setTrialOtpExpiresAt] = useState<number | null>(
+    null,
+  );
 
   useEffect(() => {
     // reset OTP stage when modal is opened/closed
@@ -156,23 +158,47 @@ export default function PlanComparison() {
 
   // Checkout modal state (local to comparison page)
   const [showCheckoutModal, setShowCheckoutModal] = useState(false);
-  const [checkoutPlan, setCheckoutPlan] = useState<{ key: string; title: string; price: string } | null>(null);
+  const [checkoutPlan, setCheckoutPlan] = useState<{
+    key: string;
+    title: string;
+    price: string;
+  } | null>(null);
   const [checkoutEmail, setCheckoutEmail] = useState("");
   const [checkoutFirstName, setCheckoutFirstName] = useState("");
   const [checkoutLastName, setCheckoutLastName] = useState("");
   const [showResultModal, setShowResultModal] = useState(false);
   const [resultDetails, setResultDetails] = useState<any>(null);
 
-  const planDetails: Record<string, { title: string; priceYearly: string; priceMonthly: string }> = {
-    trial: { title: "Trial", priceYearly: "Free (up to 7 days)", priceMonthly: "Free" },
-    basic: { title: "Basic Plan", priceYearly: "$499 / Year", priceMonthly: "$49 / Month" },
-    pro: { title: "Pro Plan", priceYearly: "$999 / Year", priceMonthly: "$99 / Month" },
-    enterprise: { title: "Enterprise Plan", priceYearly: "Contact for pricing", priceMonthly: "Contact for pricing" },
+  const planDetails: Record<
+    string,
+    { title: string; priceYearly: string; priceMonthly: string }
+  > = {
+    trial: {
+      title: "Trial",
+      priceYearly: "Free (up to 7 days)",
+      priceMonthly: "Free",
+    },
+    basic: {
+      title: "Basic Plan",
+      priceYearly: "$499 / Year",
+      priceMonthly: "$49 / Month",
+    },
+    pro: {
+      title: "Pro Plan",
+      priceYearly: "$999 / Year",
+      priceMonthly: "$99 / Month",
+    },
+    enterprise: {
+      title: "Enterprise Plan",
+      priceYearly: "Contact for pricing",
+      priceMonthly: "Contact for pricing",
+    },
   };
 
   function openCheckoutFor(key: string) {
     const details = planDetails[key];
-    const price = billingCycle === "yearly" ? details.priceYearly : details.priceMonthly;
+    const price =
+      billingCycle === "yearly" ? details.priceYearly : details.priceMonthly;
     setCheckoutPlan({ key, title: details.title, price });
     setShowCheckoutModal(true);
   }
@@ -208,7 +234,9 @@ export default function PlanComparison() {
     try {
       const axios = (await import("axios")).default;
       if (!amount || amount <= 0) {
-        alert("This plan requires custom pricing or is free. Please contact sales.");
+        alert(
+          "This plan requires custom pricing or is free. Please contact sales.",
+        );
         setShowCheckoutModal(false);
         return;
       }
@@ -225,12 +253,19 @@ export default function PlanComparison() {
       } catch (err: any) {
         console.error("Create order axios error:", err?.response || err);
         const serverErr = err?.response?.data || err?.message || String(err);
-        alert("Payment initialization failed: " + (typeof serverErr === "string" ? serverErr : JSON.stringify(serverErr)));
+        alert(
+          "Payment initialization failed: " +
+            (typeof serverErr === "string"
+              ? serverErr
+              : JSON.stringify(serverErr)),
+        );
         return;
       }
 
       if (!data || !data.ok) {
-        alert("Failed to create order: " + (data?.error || JSON.stringify(data)));
+        alert(
+          "Failed to create order: " + (data?.error || JSON.stringify(data)),
+        );
         return;
       }
 
@@ -264,12 +299,20 @@ export default function PlanComparison() {
             verifyData = { ok: false, error: err?.message || String(err) };
           }
 
-          const details = { ok: verifyData.ok, paymentResponse: response, order, verifyData };
+          const details = {
+            ok: verifyData.ok,
+            paymentResponse: response,
+            order,
+            verifyData,
+          };
           setResultDetails(details);
           setShowResultModal(true);
           setShowCheckoutModal(false);
         },
-        prefill: { name: `${checkoutFirstName} ${checkoutLastName}`, email: checkoutEmail },
+        prefill: {
+          name: `${checkoutFirstName} ${checkoutLastName}`,
+          email: checkoutEmail,
+        },
         theme: { color: "#2CADE3" },
       };
 
@@ -417,7 +460,10 @@ export default function PlanComparison() {
                 </h3>
                 <p className="text-xs text-gray-500 mb-6">/Free (7 days)</p>
               </div>
-              <button onClick={() => setShowTrialModal(true)} className="w-full bg-[#2CADE3] text-white py-2 md:py-3 text-xs font-bold rounded hover:bg-[#2399c9] transition-colors">
+              <button
+                onClick={() => setShowTrialModal(true)}
+                className="w-full bg-[#2CADE3] text-white py-2 md:py-3 text-xs font-bold rounded hover:bg-[#2399c9] transition-colors"
+              >
                 Try now
               </button>
             </div>
@@ -430,7 +476,10 @@ export default function PlanComparison() {
                 </h3>
                 <p className="text-xs text-gray-500 mb-6">/Month</p>
               </div>
-              <button onClick={() => openCheckoutFor("basic")} className="w-full bg-[#2CADE3] text-white py-2 md:py-3 text-xs font-bold rounded hover:bg-[#2399c9] transition-colors">
+              <button
+                onClick={() => openCheckoutFor("basic")}
+                className="w-full bg-[#2CADE3] text-white py-2 md:py-3 text-xs font-bold rounded hover:bg-[#2399c9] transition-colors"
+              >
                 Choose This Plan
               </button>
             </div>
@@ -443,7 +492,10 @@ export default function PlanComparison() {
                 </h3>
                 <p className="text-xs text-gray-500 mb-6">/Month</p>
               </div>
-              <button onClick={() => openCheckoutFor("pro")} className="w-full bg-[#2CADE3] text-white py-2 md:py-3 text-xs font-bold rounded hover:bg-[#2399c9] transition-colors">
+              <button
+                onClick={() => openCheckoutFor("pro")}
+                className="w-full bg-[#2CADE3] text-white py-2 md:py-3 text-xs font-bold rounded hover:bg-[#2399c9] transition-colors"
+              >
                 Choose This Plan
               </button>
             </div>
@@ -455,7 +507,10 @@ export default function PlanComparison() {
                   Custom
                 </h3>
               </div>
-              <button onClick={() => navigate('/contact')} className="w-full bg-[#2CADE3] text-white py-2 md:py-3 text-xs font-bold rounded hover:bg-[#2399c9] transition-colors">
+              <button
+                onClick={() => navigate("/contact")}
+                className="w-full bg-[#2CADE3] text-white py-2 md:py-3 text-xs font-bold rounded hover:bg-[#2399c9] transition-colors"
+              >
                 Contact Now
               </button>
             </div>
@@ -646,8 +701,12 @@ export default function PlanComparison() {
 
             <div className="p-4 sm:p-6">
               <div className="text-center mb-4">
-                <h2 className="text-xl md:text-2xl font-bold text-[#1E3A8A] mb-1">Join Our Trial on</h2>
-                <h3 className="text-xl md:text-2xl font-bold text-[#2CADE3]">{product?.name}</h3>
+                <h2 className="text-xl md:text-2xl font-bold text-[#1E3A8A] mb-1">
+                  Join Our Trial on
+                </h2>
+                <h3 className="text-xl md:text-2xl font-bold text-[#2CADE3]">
+                  {product?.name}
+                </h3>
               </div>
 
               <div className="space-y-3">
@@ -670,7 +729,10 @@ export default function PlanComparison() {
                   </>
                 ) : (
                   <>
-                    <p className="text-sm text-gray-600">Enter the 6-digit OTP sent to your email. Expires in 5 minutes.</p>
+                    <p className="text-sm text-gray-600">
+                      Enter the 6-digit OTP sent to your email. Expires in 5
+                      minutes.
+                    </p>
                     <input
                       type="text"
                       placeholder="Enter OTP"
@@ -697,7 +759,9 @@ export default function PlanComparison() {
                 )}
               </div>
 
-              <p className="text-center text-gray-500 text-xs mt-4">Submit your email address to join the trial plan</p>
+              <p className="text-center text-gray-500 text-xs mt-4">
+                Submit your email address to join the trial plan
+              </p>
             </div>
           </DialogContent>
         </DialogPortal>
@@ -714,7 +778,9 @@ export default function PlanComparison() {
               <div className="flex items-start justify-between mb-4">
                 <div>
                   <h2 className="text-xl font-bold text-[#1E3A8A]">Checkout</h2>
-                  <p className="text-sm text-gray-600">Please confirm your details to proceed to payment</p>
+                  <p className="text-sm text-gray-600">
+                    Please confirm your details to proceed to payment
+                  </p>
                 </div>
               </div>
 
@@ -723,11 +789,15 @@ export default function PlanComparison() {
                   <div className="flex items-center justify-between">
                     <div>
                       <p className="text-sm text-gray-500">Selected plan</p>
-                      <p className="font-semibold text-gray-900">{checkoutPlan.title}</p>
+                      <p className="font-semibold text-gray-900">
+                        {checkoutPlan.title}
+                      </p>
                     </div>
                     <div className="text-right">
                       <p className="text-sm text-gray-500">Amount</p>
-                      <p className="font-semibold text-gray-900">{checkoutPlan.price}</p>
+                      <p className="font-semibold text-gray-900">
+                        {checkoutPlan.price}
+                      </p>
                     </div>
                   </div>
                 </div>
@@ -735,19 +805,50 @@ export default function PlanComparison() {
 
               <div className="space-y-3">
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-                  <input type="text" placeholder="First name" value={checkoutFirstName} onChange={(e) => setCheckoutFirstName(e.target.value)} className="w-full px-3 py-2 border border-black/30 rounded-md text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#2CADE3] focus:border-transparent" />
-                  <input type="text" placeholder="Last name" value={checkoutLastName} onChange={(e) => setCheckoutLastName(e.target.value)} className="w-full px-3 py-2 border border-black/30 rounded-md text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#2CADE3] focus:border-transparent" />
+                  <input
+                    type="text"
+                    placeholder="First name"
+                    value={checkoutFirstName}
+                    onChange={(e) => setCheckoutFirstName(e.target.value)}
+                    className="w-full px-3 py-2 border border-black/30 rounded-md text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#2CADE3] focus:border-transparent"
+                  />
+                  <input
+                    type="text"
+                    placeholder="Last name"
+                    value={checkoutLastName}
+                    onChange={(e) => setCheckoutLastName(e.target.value)}
+                    className="w-full px-3 py-2 border border-black/30 rounded-md text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#2CADE3] focus:border-transparent"
+                  />
                 </div>
 
-                <input type="email" placeholder="Email address" value={checkoutEmail} onChange={(e) => setCheckoutEmail(e.target.value)} className="w-full px-3 py-2 border border-black/30 rounded-md text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#2CADE3] focus:border-transparent" />
+                <input
+                  type="email"
+                  placeholder="Email address"
+                  value={checkoutEmail}
+                  onChange={(e) => setCheckoutEmail(e.target.value)}
+                  className="w-full px-3 py-2 border border-black/30 rounded-md text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#2CADE3] focus:border-transparent"
+                />
 
                 <div className="flex gap-2">
-                  <button onClick={handleProceedToPay} className="flex-1 bg-[#2CADE3] text-white py-2 rounded-md text-sm font-medium hover:bg-[#2399c9] transition-colors">Proceed to Pay</button>
-                  <button onClick={() => setShowCheckoutModal(false)} className="flex-1 border border-gray-300 text-gray-700 py-2 rounded-md text-sm font-medium hover:bg-gray-50 transition-colors">Cancel</button>
+                  <button
+                    onClick={handleProceedToPay}
+                    className="flex-1 bg-[#2CADE3] text-white py-2 rounded-md text-sm font-medium hover:bg-[#2399c9] transition-colors"
+                  >
+                    Proceed to Pay
+                  </button>
+                  <button
+                    onClick={() => setShowCheckoutModal(false)}
+                    className="flex-1 border border-gray-300 text-gray-700 py-2 rounded-md text-sm font-medium hover:bg-gray-50 transition-colors"
+                  >
+                    Cancel
+                  </button>
                 </div>
               </div>
 
-              <p className="text-center text-gray-500 text-xs mt-4">You will be redirected to the payment gateway after clicking "Proceed to Pay".</p>
+              <p className="text-center text-gray-500 text-xs mt-4">
+                You will be redirected to the payment gateway after clicking
+                "Proceed to Pay".
+              </p>
             </div>
           </DialogContent>
         </DialogPortal>
@@ -761,10 +862,19 @@ export default function PlanComparison() {
             <DialogTitle className="sr-only">Payment Result</DialogTitle>
             {resultDetails && (
               <div>
-                <h2 className="text-xl font-bold mb-2">{resultDetails.ok ? 'Payment Successful' : 'Payment Failed'}</h2>
-                <pre className="text-xs text-gray-700 max-h-40 overflow-auto">{JSON.stringify(resultDetails, null, 2)}</pre>
+                <h2 className="text-xl font-bold mb-2">
+                  {resultDetails.ok ? "Payment Successful" : "Payment Failed"}
+                </h2>
+                <pre className="text-xs text-gray-700 max-h-40 overflow-auto">
+                  {JSON.stringify(resultDetails, null, 2)}
+                </pre>
                 <div className="mt-4 flex gap-2">
-                  <button onClick={() => setShowResultModal(false)} className="flex-1 bg-[#2CADE3] text-white py-2 rounded-md text-sm font-medium">Close</button>
+                  <button
+                    onClick={() => setShowResultModal(false)}
+                    className="flex-1 bg-[#2CADE3] text-white py-2 rounded-md text-sm font-medium"
+                  >
+                    Close
+                  </button>
                 </div>
               </div>
             )}

--- a/client/pages/pricing/PlanComparison.tsx
+++ b/client/pages/pricing/PlanComparison.tsx
@@ -442,9 +442,9 @@ export default function PlanComparison() {
                 <h3 className="text-base md:text-lg font-bold text-gray-900 mb-2">
                   Compare plans
                 </h3>
-                <div className="inline-flex items-center justify-center px-3 py-1 rounded-full border border-gray-400 mb-2">
+                {/* <div className="inline-flex items-center justify-center px-3 py-1 rounded-full border border-gray-400 mb-2">
                   <span className="text-gray-900 font-medium">40% Off</span>
-                </div>
+                </div> */}
                 <p className="text-xs text-gray-500">
                   Choose your workspace plan according to your organisational
                   plan

--- a/client/pages/pricing/PlanComparison.tsx
+++ b/client/pages/pricing/PlanComparison.tsx
@@ -1,4 +1,3 @@
-import { useParams, useNavigate } from "react-router-dom";
 import * as Router from "react-router-dom";
 import Footer from "@/components/layout/Footer";
 import { ChevronDown, ChevronRight } from "lucide-react";

--- a/client/pages/pricing/PlanComparison.tsx
+++ b/client/pages/pricing/PlanComparison.tsx
@@ -58,8 +58,8 @@ const faqs = [
 ];
 
 export default function PlanComparison() {
-  const { productSlug } = Router.useParams<{ productSlug: string }>();
-  const navigate = Router.useNavigate();
+  const { productSlug } = useParams<{ productSlug: string }>();
+  const navigate = useNavigate();
   const [expandedFaq, setExpandedFaq] = useState<number | null>(1);
   const [billingCycle, setBillingCycle] = useState<"yearly" | "monthly">(
     "yearly",

--- a/client/pages/pricing/PlanComparison.tsx
+++ b/client/pages/pricing/PlanComparison.tsx
@@ -310,7 +310,7 @@ export default function PlanComparison() {
                 </h3>
                 <p className="text-xs text-gray-500 mb-6">/Month</p>
               </div>
-              <button onClick={() => navigate(`/pricing/${productSlug}?action=checkout&plan=pro`)} className="w-full bg-[#2CADE3] text-white py-2 md:py-3 text-xs font-bold rounded hover:bg-[#2399c9] transition-colors">
+              <button onClick={() => navigate(`/pricing/${productSlug}?action=checkout&plan=pro&from=compare`)} className="w-full bg-[#2CADE3] text-white py-2 md:py-3 text-xs font-bold rounded hover:bg-[#2399c9] transition-colors">
                 Choose This Plan
               </button>
             </div>

--- a/client/pages/pricing/PlanComparison.tsx
+++ b/client/pages/pricing/PlanComparison.tsx
@@ -1,5 +1,5 @@
-import * as Router from "react-router-dom";
-import * as Router from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import Footer from "@/components/layout/Footer";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { useState } from "react";

--- a/client/pages/pricing/PlanComparison.tsx
+++ b/client/pages/pricing/PlanComparison.tsx
@@ -58,8 +58,8 @@ const faqs = [
 ];
 
 export default function PlanComparison() {
-  const { productSlug } = useParams<{ productSlug: string }>();
-  const navigate = useNavigate();
+  const { productSlug } = Router.useParams<{ productSlug: string }>();
+  const navigate = Router.useNavigate();
   const [expandedFaq, setExpandedFaq] = useState<number | null>(1);
   const [billingCycle, setBillingCycle] = useState<"yearly" | "monthly">(
     "yearly",

--- a/client/pages/pricing/PlanComparison.tsx
+++ b/client/pages/pricing/PlanComparison.tsx
@@ -1,5 +1,4 @@
 import { useParams, useNavigate } from "react-router-dom";
-import { useParams, useNavigate } from "react-router-dom";
 import Footer from "@/components/layout/Footer";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { useState } from "react";

--- a/client/pages/pricing/PlanComparison.tsx
+++ b/client/pages/pricing/PlanComparison.tsx
@@ -297,7 +297,7 @@ export default function PlanComparison() {
                 </h3>
                 <p className="text-xs text-gray-500 mb-6">/Month</p>
               </div>
-              <button onClick={() => navigate(`/pricing/${productSlug}?action=checkout&plan=basic`)} className="w-full bg-[#2CADE3] text-white py-2 md:py-3 text-xs font-bold rounded hover:bg-[#2399c9] transition-colors">
+              <button onClick={() => navigate(`/pricing/${productSlug}?action=checkout&plan=basic&from=compare`)} className="w-full bg-[#2CADE3] text-white py-2 md:py-3 text-xs font-bold rounded hover:bg-[#2399c9] transition-colors">
                 Choose This Plan
               </button>
             </div>

--- a/client/pages/pricing/PlanComparison.tsx
+++ b/client/pages/pricing/PlanComparison.tsx
@@ -1,4 +1,5 @@
 import * as Router from "react-router-dom";
+import * as Router from "react-router-dom";
 import Footer from "@/components/layout/Footer";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { useState } from "react";

--- a/client/pages/pricing/PlanComparison.tsx
+++ b/client/pages/pricing/PlanComparison.tsx
@@ -443,7 +443,7 @@ export default function PlanComparison() {
                 </h3>
                 <p className="text-xs text-gray-500 mb-6">/Month</p>
               </div>
-              <button onClick={() => navigate(`/pricing/${productSlug}?action=checkout&plan=pro&from=compare`)} className="w-full bg-[#2CADE3] text-white py-2 md:py-3 text-xs font-bold rounded hover:bg-[#2399c9] transition-colors">
+              <button onClick={() => openCheckoutFor("pro")} className="w-full bg-[#2CADE3] text-white py-2 md:py-3 text-xs font-bold rounded hover:bg-[#2399c9] transition-colors">
                 Choose This Plan
               </button>
             </div>

--- a/client/pages/pricing/PlanComparison.tsx
+++ b/client/pages/pricing/PlanComparison.tsx
@@ -196,7 +196,7 @@ export default function PlanComparison() {
                 </h3>
                 <p className="text-xs text-gray-500 mb-6">/Free (7 days)</p>
               </div>
-              <button onClick={() => navigate(`/pricing/${productSlug}?action=trial`)} className="w-full bg-[#2CADE3] text-white py-2 md:py-3 text-xs font-bold rounded hover:bg-[#2399c9] transition-colors">
+              <button onClick={() => navigate(`/pricing/${productSlug}?action=trial&from=compare`)} className="w-full bg-[#2CADE3] text-white py-2 md:py-3 text-xs font-bold rounded hover:bg-[#2399c9] transition-colors">
                 Try now
               </button>
             </div>

--- a/client/pages/pricing/PlanComparison.tsx
+++ b/client/pages/pricing/PlanComparison.tsx
@@ -1,4 +1,5 @@
 import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import Footer from "@/components/layout/Footer";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { useState } from "react";

--- a/client/pages/pricing/PlanComparison.tsx
+++ b/client/pages/pricing/PlanComparison.tsx
@@ -1,5 +1,5 @@
 import { useParams, useNavigate } from "react-router-dom";
-import { useParams, useNavigate } from "react-router-dom";
+import * as Router from "react-router-dom";
 import Footer from "@/components/layout/Footer";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { useState } from "react";

--- a/client/pages/pricing/PlanComparison.tsx
+++ b/client/pages/pricing/PlanComparison.tsx
@@ -703,6 +703,75 @@ export default function PlanComparison() {
         </DialogPortal>
       </Dialog>
 
+      {/* Checkout Modal */}
+      <Dialog open={showCheckoutModal} onOpenChange={setShowCheckoutModal}>
+        <DialogPortal>
+          <DialogOverlay className="bg-white/80 backdrop-blur-md" />
+          <DialogContent className="max-w-md p-4 sm:p-6 rounded-xl shadow-2xl">
+            <DialogTitle className="sr-only">Checkout</DialogTitle>
+
+            <div className="p-4 sm:p-6">
+              <div className="flex items-start justify-between mb-4">
+                <div>
+                  <h2 className="text-xl font-bold text-[#1E3A8A]">Checkout</h2>
+                  <p className="text-sm text-gray-600">Please confirm your details to proceed to payment</p>
+                </div>
+              </div>
+
+              {checkoutPlan && (
+                <div className="mb-4 p-3 border border-gray-100 rounded-md bg-white">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-sm text-gray-500">Selected plan</p>
+                      <p className="font-semibold text-gray-900">{checkoutPlan.title}</p>
+                    </div>
+                    <div className="text-right">
+                      <p className="text-sm text-gray-500">Amount</p>
+                      <p className="font-semibold text-gray-900">{checkoutPlan.price}</p>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              <div className="space-y-3">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                  <input type="text" placeholder="First name" value={checkoutFirstName} onChange={(e) => setCheckoutFirstName(e.target.value)} className="w-full px-3 py-2 border border-black/30 rounded-md text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#2CADE3] focus:border-transparent" />
+                  <input type="text" placeholder="Last name" value={checkoutLastName} onChange={(e) => setCheckoutLastName(e.target.value)} className="w-full px-3 py-2 border border-black/30 rounded-md text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#2CADE3] focus:border-transparent" />
+                </div>
+
+                <input type="email" placeholder="Email address" value={checkoutEmail} onChange={(e) => setCheckoutEmail(e.target.value)} className="w-full px-3 py-2 border border-black/30 rounded-md text-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-[#2CADE3] focus:border-transparent" />
+
+                <div className="flex gap-2">
+                  <button onClick={handleProceedToPay} className="flex-1 bg-[#2CADE3] text-white py-2 rounded-md text-sm font-medium hover:bg-[#2399c9] transition-colors">Proceed to Pay</button>
+                  <button onClick={() => setShowCheckoutModal(false)} className="flex-1 border border-gray-300 text-gray-700 py-2 rounded-md text-sm font-medium hover:bg-gray-50 transition-colors">Cancel</button>
+                </div>
+              </div>
+
+              <p className="text-center text-gray-500 text-xs mt-4">You will be redirected to the payment gateway after clicking "Proceed to Pay".</p>
+            </div>
+          </DialogContent>
+        </DialogPortal>
+      </Dialog>
+
+      {/* Payment result modal */}
+      <Dialog open={showResultModal} onOpenChange={setShowResultModal}>
+        <DialogPortal>
+          <DialogOverlay className="bg-black/50 backdrop-blur-sm" />
+          <DialogContent className="max-w-md p-4 sm:p-6 rounded-xl shadow-2xl">
+            <DialogTitle className="sr-only">Payment Result</DialogTitle>
+            {resultDetails && (
+              <div>
+                <h2 className="text-xl font-bold mb-2">{resultDetails.ok ? 'Payment Successful' : 'Payment Failed'}</h2>
+                <pre className="text-xs text-gray-700 max-h-40 overflow-auto">{JSON.stringify(resultDetails, null, 2)}</pre>
+                <div className="mt-4 flex gap-2">
+                  <button onClick={() => setShowResultModal(false)} className="flex-1 bg-[#2CADE3] text-white py-2 rounded-md text-sm font-medium">Close</button>
+                </div>
+              </div>
+            )}
+          </DialogContent>
+        </DialogPortal>
+      </Dialog>
+
       <Footer />
     </div>
   );

--- a/client/pages/pricing/Pricing.tsx
+++ b/client/pages/pricing/Pricing.tsx
@@ -335,6 +335,7 @@ export default function PromotionPlans() {
 </AnimatePresence>
 
 
+      <Footer />
     </div>
   );
 }

--- a/client/pages/pricing/Pricing.tsx
+++ b/client/pages/pricing/Pricing.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
+import Footer from "@/components/layout/Footer";
 
 const plans = [
   {

--- a/client/pages/pricing/Pricing.tsx
+++ b/client/pages/pricing/Pricing.tsx
@@ -94,7 +94,7 @@ const products = [
       ENTERPRISE: 1550,
     },
   },
-   {
+  {
     name: "Mylapay SwitchX",
     prices: {
       STARTER: 560,
@@ -102,7 +102,6 @@ const products = [
       ENTERPRISE: 1550,
     },
   },
-
 ];
 
 export default function PromotionPlans() {
@@ -224,116 +223,123 @@ export default function PromotionPlans() {
       </div>
 
       {/* Modal */}
-<AnimatePresence>
-  {isModalOpen && (
-    <motion.div
-      className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50"
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      exit={{ opacity: 0 }}
-      transition={{ duration: 0.15 }}
-    >
-      <motion.div
-        className="bg-white rounded-2xl p-6 w-11/12 sm:w-96 shadow-lg relative"
-        initial={{ scale: 0.95, opacity: 0 }}
-        animate={{ scale: 1, opacity: 1 }}
-        exit={{ scale: 0.95, opacity: 0 }}
-        transition={{ duration: 0.2, ease: "easeOut" }}
-      >
-        {/* Close button */}
-        <button
-          onClick={closeModal}
-          className="absolute top-2 right-3 text-gray-500 hover:text-black text-xl"
-        >
-          ✕
-        </button>
-
-        {/* Modal Heading */}
-        <h3 className="text-xl font-semibold mb-4 text-center">
-          Select Your Product(s)
-        </h3>
-
-        {/* Multi-select dropdown */}
-        <div className="relative w-full mb-4">
-  <button
-    type="button"
-    onClick={() => setDropdownOpen(!dropdownOpen)}
-    className="w-full border rounded-lg p-2 text-left flex justify-between items-center bg-white"
-  >
-    {selectedProduct.length > 0
-      ? `${selectedProduct.length} product(s) selected`
-      : "Select Product(s)"}
-    <span className="ml-2">&#9662;</span>
-  </button>
-
-  {dropdownOpen && (
-    <div className="absolute z-10 w-full max-h-60 overflow-auto bg-white border rounded-lg mt-1 shadow-lg">
-      {products.map((product) => {
-        const isSelected = selectedProduct.includes(product.name);
-        return (
-          <label
-            key={product.name}
-            className="flex items-center justify-between px-3 py-2 cursor-pointer hover:bg-gray-100"
-          >
-            <span>{product.name}</span>
-            <input
-              type="checkbox"
-              checked={isSelected}
-              onChange={() => {
-                if (isSelected) {
-                  setSelectedProduct(selectedProduct.filter((p) => p !== product.name));
-                } else {
-                  setSelectedProduct([...selectedProduct, product.name]);
-                }
-              }}
-            />
-          </label>
-        );
-      })}
-    </div>
-  )}
-</div>
-
-
-        {/* Selected Products display as pills */}
-        {selectedProduct.length > 0 && (
+      <AnimatePresence>
+        {isModalOpen && (
           <motion.div
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-            className="text-center mt-3"
+            className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.15 }}
           >
-            <p className="text-gray-700">
-              Selected Plan:{" "}
-              <span className="font-bold text-blue-600">{selectedPlan}</span>
-            </p>
-            <p className="text-gray-700 mb-2">Selected Product(s):</p>
-            <div className="flex flex-wrap gap-2 justify-center">
-              {selectedProduct.map((product) => (
-                <span
-                  key={product}
-                  className="bg-blue-100 text-blue-800 px-3 py-1 rounded-full text-sm font-medium"
+            <motion.div
+              className="bg-white rounded-2xl p-6 w-11/12 sm:w-96 shadow-lg relative"
+              initial={{ scale: 0.95, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              exit={{ scale: 0.95, opacity: 0 }}
+              transition={{ duration: 0.2, ease: "easeOut" }}
+            >
+              {/* Close button */}
+              <button
+                onClick={closeModal}
+                className="absolute top-2 right-3 text-gray-500 hover:text-black text-xl"
+              >
+                ✕
+              </button>
+
+              {/* Modal Heading */}
+              <h3 className="text-xl font-semibold mb-4 text-center">
+                Select Your Product(s)
+              </h3>
+
+              {/* Multi-select dropdown */}
+              <div className="relative w-full mb-4">
+                <button
+                  type="button"
+                  onClick={() => setDropdownOpen(!dropdownOpen)}
+                  className="w-full border rounded-lg p-2 text-left flex justify-between items-center bg-white"
                 >
-                  {product}
-                </span>
-              ))}
-            </div>
+                  {selectedProduct.length > 0
+                    ? `${selectedProduct.length} product(s) selected`
+                    : "Select Product(s)"}
+                  <span className="ml-2">&#9662;</span>
+                </button>
+
+                {dropdownOpen && (
+                  <div className="absolute z-10 w-full max-h-60 overflow-auto bg-white border rounded-lg mt-1 shadow-lg">
+                    {products.map((product) => {
+                      const isSelected = selectedProduct.includes(product.name);
+                      return (
+                        <label
+                          key={product.name}
+                          className="flex items-center justify-between px-3 py-2 cursor-pointer hover:bg-gray-100"
+                        >
+                          <span>{product.name}</span>
+                          <input
+                            type="checkbox"
+                            checked={isSelected}
+                            onChange={() => {
+                              if (isSelected) {
+                                setSelectedProduct(
+                                  selectedProduct.filter(
+                                    (p) => p !== product.name,
+                                  ),
+                                );
+                              } else {
+                                setSelectedProduct([
+                                  ...selectedProduct,
+                                  product.name,
+                                ]);
+                              }
+                            }}
+                          />
+                        </label>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+
+              {/* Selected Products display as pills */}
+              {selectedProduct.length > 0 && (
+                <motion.div
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  className="text-center mt-3"
+                >
+                  <p className="text-gray-700">
+                    Selected Plan:{" "}
+                    <span className="font-bold text-blue-600">
+                      {selectedPlan}
+                    </span>
+                  </p>
+                  <p className="text-gray-700 mb-2">Selected Product(s):</p>
+                  <div className="flex flex-wrap gap-2 justify-center">
+                    {selectedProduct.map((product) => (
+                      <span
+                        key={product}
+                        className="bg-blue-100 text-blue-800 px-3 py-1 rounded-full text-sm font-medium"
+                      >
+                        {product}
+                      </span>
+                    ))}
+                  </div>
+                </motion.div>
+              )}
+
+              {/* Confirm button */}
+              <div className="mt-6 text-center">
+                <button
+                  onClick={closeModal}
+                  className="px-5 py-2 bg-blue-600 text-white rounded-lg font-semibold hover:scale-105 transition-transform"
+                >
+                  Confirm
+                </button>
+              </div>
+            </motion.div>
           </motion.div>
         )}
-
-        {/* Confirm button */}
-        <div className="mt-6 text-center">
-          <button
-            onClick={closeModal}
-            className="px-5 py-2 bg-blue-600 text-white rounded-lg font-semibold hover:scale-105 transition-transform"
-          >
-            Confirm
-          </button>
-        </div>
-      </motion.div>
-    </motion.div>
-  )}
-</AnimatePresence>
-
+      </AnimatePresence>
 
       <Footer />
     </div>

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -64,9 +64,9 @@ const planDetails: Record<
 };
 
 export default function ProductPricing() {
-  const { productSlug } = Router.useParams<{ productSlug: string }>();
-  const navigate = Router.useNavigate();
-  const location = Router.useLocation();
+  const { productSlug } = useParams<{ productSlug: string }>();
+  const navigate = useNavigate();
+  const location = useLocation();
   const [billingCycle, setBillingCycle] = useState<"yearly" | "monthly">(
     "yearly",
   );

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -64,9 +64,9 @@ const planDetails: Record<
 };
 
 export default function ProductPricing() {
-  const { productSlug } = useParams<{ productSlug: string }>();
-  const navigate = useNavigate();
-  const location = useLocation();
+  const { productSlug } = Router.useParams<{ productSlug: string }>();
+  const navigate = Router.useNavigate();
+  const location = Router.useLocation();
   const [billingCycle, setBillingCycle] = useState<"yearly" | "monthly">(
     "yearly",
   );

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -321,6 +321,28 @@ export default function ProductPricing() {
     }
   }
 
+  // Listen to URL search params to open modals directly (e.g., from comparison page links)
+  useEffect(() => {
+    try {
+      const sp = new URLSearchParams(location.search);
+      const action = sp.get("action");
+      if (action === "trial") {
+        setShowTrialModal(true);
+      }
+      if (action === "checkout") {
+        const plan = sp.get("plan");
+        if (plan && planDetails[plan]) {
+          const details = planDetails[plan];
+          const price = billingCycle === "yearly" ? details.priceYearly : details.priceMonthly;
+          setCheckoutPlan({ key: plan, title: details.title, price });
+          setShowCheckoutModal(true);
+        }
+      }
+    } catch (e) {
+      // ignore
+    }
+  }, [location.search, billingCycle]);
+
   return (
     <div className="min-h-[calc(100vh-4rem)] bg-white pt-16 md:pt-20 pb-8 lg:pb-12 px-4 sm:px-6 lg:px-8 overflow-hidden">
       <div className="max-w-7xl mx-auto">

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -66,6 +66,7 @@ const planDetails: Record<
 export default function ProductPricing() {
   const { productSlug } = useParams<{ productSlug: string }>();
   const navigate = useNavigate();
+  const location = useLocation();
   const [billingCycle, setBillingCycle] = useState<"yearly" | "monthly">(
     "yearly",
   );

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -334,7 +334,10 @@ export default function ProductPricing() {
         const plan = sp.get("plan");
         if (plan && planDetails[plan]) {
           const details = planDetails[plan];
-          const price = billingCycle === "yearly" ? details.priceYearly : details.priceMonthly;
+          const price =
+            billingCycle === "yearly"
+              ? details.priceYearly
+              : details.priceMonthly;
           setCheckoutPlan({ key: plan, title: details.title, price });
           setShowCheckoutModal(true);
         }
@@ -653,7 +656,10 @@ export default function ProductPricing() {
                 </div>
               </div>
 
-              <button onClick={() => navigate('/contact')} className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium transition-colors group-hover:bg-white group-hover:text-[#052343]">
+              <button
+                onClick={() => navigate("/contact")}
+                className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium transition-colors group-hover:bg-white group-hover:text-[#052343]"
+              >
                 Contact Now
               </button>
               <div className="flex justify-center mt-3">

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -861,6 +861,9 @@ export default function ProductPricing() {
           </DialogContent>
         </DialogPortal>
       </Dialog>
+
+      {/* Footer */}
+      <Footer />
     </div>
   );
 }

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -596,7 +596,7 @@ export default function ProductPricing() {
                 </div>
               </div>
 
-              <button className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium transition-colors group-hover:bg-white group-hover:text-[#052343]">
+              <button onClick={() => navigate('/contact')} className="w-full bg-[#2CADE3] text-white py-3 text-sm rounded font-medium transition-colors group-hover:bg-white group-hover:text-[#052343]">
                 Contact Now
               </button>
               <div className="flex justify-center mt-3">

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -1,5 +1,5 @@
-import { useParams, useNavigate, useLocation } from "react-router-dom";
-import { useParams, useNavigate, useLocation } from "react-router-dom";
+import * as Router from "react-router-dom";
+import * as Router from "react-router-dom";
 import { Check, X } from "lucide-react";
 import { useState, useEffect } from "react";
 import { toast } from "@/hooks/use-toast";

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -1,5 +1,4 @@
 import { useParams, useNavigate, useLocation } from "react-router-dom";
-import { useParams, useNavigate, useLocation } from "react-router-dom";
 import { Check, X } from "lucide-react";
 import { useState, useEffect } from "react";
 import { toast } from "@/hooks/use-toast";

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -1,5 +1,5 @@
-import * as Router from "react-router-dom";
-import * as Router from "react-router-dom";
+import { useParams, useNavigate, useLocation } from "react-router-dom";
+import { useParams, useNavigate, useLocation } from "react-router-dom";
 import { Check, X } from "lucide-react";
 import { useState, useEffect } from "react";
 import { toast } from "@/hooks/use-toast";

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -640,9 +640,7 @@ export default function ProductPricing() {
         <DialogPortal>
           <DialogOverlay className="bg-white/70 backdrop-blur-md" />
           <DialogContent className="max-w-md p-4 sm:p-6 rounded-xl shadow-2xl">
-            <DialogTitle className="sr-only">
-              Join Our Trial on Token X
-            </DialogTitle>
+            <DialogTitle className="sr-only">{`Join Our Trial on ${product.name}`}</DialogTitle>
 
             <div className="p-4 sm:p-6">
               <div className="text-center mb-4">

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -379,7 +379,7 @@ export default function ProductPricing() {
   }, [showCheckoutModal, location.search, productSlug, navigate]);
 
   return (
-    <div className="min-h-[calc(100vh-4rem)] bg-white pt-16 md:pt-20 pb-8 lg:pb-12 px-4 sm:px-6 lg:px-8 overflow-hidden">
+    <div className="min-h-[calc(100vh-4rem)] bg-white pt-16 md:pt-20 pb-0 px-4 sm:px-6 lg:px-8 overflow-hidden">
       <div className="max-w-7xl mx-auto">
         {/* Header Section */}
         <div className="text-center mb-12">

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -361,6 +361,23 @@ export default function ProductPricing() {
     }
   }, [showTrialModal, location.search, productSlug, navigate]);
 
+  // When the checkout modal is closed and opened from the compare page,
+  // navigate back to the compare route so users return to the plan comparison
+  useEffect(() => {
+    try {
+      if (!showCheckoutModal) {
+        const sp = new URLSearchParams(location.search);
+        const from = sp.get("from");
+        const action = sp.get("action");
+        if (from === "compare" && action === "checkout") {
+          navigate(`/pricing/${productSlug}/compare`);
+        }
+      }
+    } catch (e) {
+      // ignore
+    }
+  }, [showCheckoutModal, location.search, productSlug, navigate]);
+
   return (
     <div className="min-h-[calc(100vh-4rem)] bg-white pt-16 md:pt-20 pb-8 lg:pb-12 px-4 sm:px-6 lg:px-8 overflow-hidden">
       <div className="max-w-7xl mx-auto">

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -1,4 +1,5 @@
 import { useParams, useNavigate, useLocation } from "react-router-dom";
+import { useParams, useNavigate, useLocation } from "react-router-dom";
 import { Check, X } from "lucide-react";
 import { useState, useEffect } from "react";
 import { toast } from "@/hooks/use-toast";

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -1,6 +1,6 @@
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, useLocation } from "react-router-dom";
 import { Check, X } from "lucide-react";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { toast } from "@/hooks/use-toast";
 import {
   Dialog,
@@ -9,6 +9,7 @@ import {
   DialogPortal,
   DialogTitle,
 } from "@/components/ui/dialog";
+import Footer from "@/components/layout/Footer";
 
 const products = [
   { slug: "mylapay-tokenx", name: "TokenX", fullName: "Mylapay TokenX" },

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -344,6 +344,23 @@ export default function ProductPricing() {
     }
   }, [location.search, billingCycle]);
 
+  // When the trial modal is closed and it was opened from the compare page,
+  // navigate back to the compare route so users return to the plan comparison
+  useEffect(() => {
+    try {
+      if (!showTrialModal) {
+        const sp = new URLSearchParams(location.search);
+        const from = sp.get("from");
+        const action = sp.get("action");
+        if (from === "compare" && action === "trial") {
+          navigate(`/pricing/${productSlug}/compare`);
+        }
+      }
+    } catch (e) {
+      // ignore
+    }
+  }, [showTrialModal, location.search, productSlug, navigate]);
+
   return (
     <div className="min-h-[calc(100vh-4rem)] bg-white pt-16 md:pt-20 pb-8 lg:pb-12 px-4 sm:px-6 lg:px-8 overflow-hidden">
       <div className="max-w-7xl mx-auto">
@@ -648,7 +665,7 @@ export default function ProductPricing() {
                   Join Our Trial on
                 </h2>
                 <h3 className="text-xl md:text-2xl font-bold text-[#2CADE3]">
-                  Token X
+                  {product.name}
                 </h3>
               </div>
 

--- a/client/pages/pricing/ProductPricing.tsx
+++ b/client/pages/pricing/ProductPricing.tsx
@@ -382,8 +382,9 @@ export default function ProductPricing() {
   }, [showCheckoutModal, location.search, productSlug, navigate]);
 
   return (
+    <>
     <div className="min-h-[calc(100vh-4rem)] bg-white pt-16 md:pt-20 pb-0 px-4 sm:px-6 lg:px-8 overflow-hidden">
-      <div className="max-w-7xl mx-auto">
+      <div className="max-w-7xl mx-auto pb-10">
         {/* Header Section */}
         <div className="text-center mb-12">
           <h1 className="text-3xl md:text-4xl font-bold mb-3">
@@ -902,7 +903,9 @@ export default function ProductPricing() {
       </Dialog>
 
       {/* Footer */}
-      <Footer />
+      
     </div>
+    <Footer />
+    </>
   );
 }

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4870,5 +4870,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:12:14.490Z"
+  },
+  {
+    "page": "/",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-22T06:19:53.049Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5746,5 +5746,41 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-cswitch",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:59:29.010Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:59:43.073Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "sessionId": "sess_pbs0w1lw",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:59:53.861Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5470,5 +5470,53 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_9q0lh7ih",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:49:33.735Z"
+  },
+  {
+    "page": "/pricing/mylapay-cswitch/compare",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:49:42.994Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-cswitch/compare",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:49:52.750Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-cswitch?action=checkout&plan=basic",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:50:16.552Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4702,5 +4702,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:03:23.133Z"
+  },
+  {
+    "page": "/pricing/mylapay-secure",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-22T06:03:32.554Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5794,5 +5794,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T07:00:44.683Z"
+  },
+  {
+    "sessionId": "sess_eb4omd6y",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T07:01:24.507Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4726,5 +4726,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:03:39.197Z"
+  },
+  {
+    "sessionId": "sess_w9t1y93e",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:03:47.483Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5002,5 +5002,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:31:26.555Z"
+  },
+  {
+    "page": "/pricing/mylapay-secure",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:31:32.947Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4678,5 +4678,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-secure",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:03:09.260Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5554,5 +5554,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-cswitch",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-22T06:51:38.754Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5806,5 +5806,29 @@
       "ll": null
     },
     "timestamp": "2025-11-22T07:01:24.507Z"
+  },
+  {
+    "page": "/pricing/mylapay-cswitch",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-22T07:01:59.732Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-secure",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T07:02:27.601Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5014,5 +5014,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-secure",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-22T06:34:16.667Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5842,5 +5842,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T07:04:39.967Z"
+  },
+  {
+    "page": "/pricing/mylapay-cswitch",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-22T07:05:11.158Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4534,5 +4534,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:00:40.494Z"
+  },
+  {
+    "sessionId": "sess_qervhmv0",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:00:45.632Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5638,5 +5638,29 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-cswitch/compare",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-22T06:54:30.014Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-cswitch/compare",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-22T06:54:41.403Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4558,5 +4558,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:00:56.234Z"
+  },
+  {
+    "sessionId": "sess_bq0rwm8x",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:01:09.318Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5722,5 +5722,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:57:35.376Z"
+  },
+  {
+    "sessionId": "sess_b0onqn81",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:59:06.072Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5530,5 +5530,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:51:02.426Z"
+  },
+  {
+    "sessionId": "sess_6o5yzk6w",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:51:20.570Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5074,5 +5074,29 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:35:36.693Z"
+  },
+  {
+    "sessionId": "sess_qzbeta94",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:35:44.377Z"
+  },
+  {
+    "page": "/",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:36:07.068Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4654,5 +4654,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:02:41.718Z"
+  },
+  {
+    "page": "/pricing/mylapay-secure",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:02:46.783Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4846,5 +4846,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:12:06.007Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4906,5 +4906,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_sir07ffx",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:27:34.745Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5194,5 +5194,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_0nbk1fbo",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:37:51.075Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5182,5 +5182,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-22T06:37:42.956Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5170,5 +5170,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:37:13.259Z"
+  },
+  {
+    "page": "/",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:37:19.416Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5566,5 +5566,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-cswitch",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-22T06:51:48.384Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4606,5 +4606,29 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_m1brcglm",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:01:55.063Z"
+  },
+  {
+    "page": "/pricing/mylapay-secure",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:02:04.889Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4666,5 +4666,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-secure",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-22T06:03:02.772Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4750,5 +4750,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-secure",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-22T06:04:04.119Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4762,5 +4762,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-secure",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-22T06:04:10.270Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5518,5 +5518,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_18xvvlik",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:51:02.426Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5626,5 +5626,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:53:24.216Z"
+  },
+  {
+    "page": "/pricing/mylapay-cswitch/compare",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-22T06:54:20.598Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5110,5 +5110,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:36:23.246Z"
+  },
+  {
+    "sessionId": "sess_81czkwtz",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:36:33.847Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4882,5 +4882,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_vaf21byy",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:20:08.016Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5050,5 +5050,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:35:12.021Z"
+  },
+  {
+    "sessionId": "sess_4csz1htr",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:35:30.412Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5326,5 +5326,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:44:39.080Z"
+  },
+  {
+    "page": "/pricing/mylapay-intellesolve",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:44:46.014Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5662,5 +5662,53 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_te16f08y",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:54:50.856Z"
+  },
+  {
+    "page": "/pricing/mylapay-cswitch",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:54:58.868Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-cswitch/compare",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:55:04.353Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-cswitch",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:55:21.076Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4498,5 +4498,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_wfqys18c",
+    "duration": 3,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:00:25.794Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4810,5 +4810,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:10:32.346Z"
+  },
+  {
+    "sessionId": "sess_ze5eundg",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:10:37.787Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4990,5 +4990,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_pjtst3lq",
+    "duration": 4,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:31:26.555Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5026,5 +5026,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_q14fc3hs",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:35:06.008Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5602,5 +5602,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_lovdauwz",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:53:16.502Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5134,5 +5134,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:36:39.850Z"
+  },
+  {
+    "sessionId": "sess_nqiiwvah",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:36:56.572Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4774,5 +4774,29 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-secure",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:04:16.005Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:04:22.936Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5218,5 +5218,101 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_ndypolod",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:38:07.775Z"
+  },
+  {
+    "page": "/pricing/mylapay-secure",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:38:28.729Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-secure/compare",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:38:34.515Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-secure/compare",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:38:42.208Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-secure/compare",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:38:57.001Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-secure?action=trial",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:39:08.004Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-secure/compare",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:39:15.563Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:39:20.819Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5734,5 +5734,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:59:06.072Z"
+  },
+  {
+    "page": "/pricing/mylapay-cswitch",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-22T06:59:21.607Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4714,5 +4714,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_9yi50qa1",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:03:39.197Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4690,5 +4690,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_s0qz2yu7",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:03:23.133Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4546,5 +4546,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:00:45.632Z"
+  },
+  {
+    "sessionId": "sess_ysp9z62c",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:00:56.234Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5458,5 +5458,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-cswitch",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:48:59.656Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5710,5 +5710,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_pfn1awrz",
+    "duration": 3,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:57:35.376Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4594,5 +4594,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:01:43.891Z"
+  },
+  {
+    "page": "/pricing/mylapay-secure",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:01:49.633Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5782,5 +5782,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:59:53.861Z"
+  },
+  {
+    "sessionId": "sess_2f4puela",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T07:00:44.683Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4894,5 +4894,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:20:08.016Z"
+  },
+  {
+    "page": "/",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-22T06:27:25.731Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4858,5 +4858,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_b98rjhcy",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:12:14.490Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5830,5 +5830,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_z5ryatcn",
+    "duration": 3,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T07:04:39.967Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5422,5 +5422,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_g6dfrr7r",
+    "duration": 2,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:48:33.505Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5542,5 +5542,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:51:20.570Z"
+  },
+  {
+    "page": "/pricing/mylapay-cswitch",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:51:26.238Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4414,5 +4414,89 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T05:57:19.466Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-secure",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T05:57:24.617Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-secure",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T05:57:30.734Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-secure/compare",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T05:58:11.364Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-secure",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T05:59:00.093Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/products/mylapay-secure",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T05:59:35.583Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-secure",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:00:08.227Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5038,5 +5038,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:35:06.008Z"
+  },
+  {
+    "sessionId": "sess_diqdyr3t",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:35:12.021Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5578,5 +5578,29 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-cswitch",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-22T06:51:55.238Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-cswitch?action=checkout&plan=basic&from=compare",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:52:00.601Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5362,5 +5362,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-intellesolve",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-22T06:45:42.423Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5314,5 +5314,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_t485rrow",
+    "duration": 6,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:44:39.080Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4834,5 +4834,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:11:31.367Z"
+  },
+  {
+    "page": "/",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-22T06:11:59.556Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5206,5 +5206,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:37:51.075Z"
+  },
+  {
+    "page": "/",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:37:57.781Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5062,5 +5062,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:35:30.412Z"
+  },
+  {
+    "sessionId": "sess_3jpx8xta",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:35:36.693Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5098,5 +5098,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_mqzsp3bu",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:36:23.246Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4822,5 +4822,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:10:37.787Z"
+  },
+  {
+    "sessionId": "sess_xvkrf5wn",
+    "duration": 1,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:11:31.367Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5614,5 +5614,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:53:16.502Z"
+  },
+  {
+    "sessionId": "sess_pdeon53a",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:53:24.216Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5122,5 +5122,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:36:33.847Z"
+  },
+  {
+    "sessionId": "sess_y8ljyn86",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:36:39.850Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5158,5 +5158,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_v8nly2w8",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:37:13.259Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5350,5 +5350,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-intellesolve",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-22T06:45:35.722Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4630,5 +4630,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_wp5k1vgc",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:02:32.634Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5854,5 +5854,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-cswitch",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-22T07:05:19.059Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4798,5 +4798,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "sessionId": "sess_q7t8zpzn",
+    "duration": 6,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:10:32.346Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4570,5 +4570,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:01:09.318Z"
+  },
+  {
+    "sessionId": "sess_o7yich6n",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:01:25.185Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4642,5 +4642,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:02:32.634Z"
+  },
+  {
+    "sessionId": "sess_n25m3hi9",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:02:41.718Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5338,5 +5338,17 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-intellesolve",
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36",
+    "timestamp": "2025-11-22T06:45:24.275Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4522,5 +4522,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:00:31.408Z"
+  },
+  {
+    "sessionId": "sess_bi3rydd0",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:00:40.494Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5866,5 +5866,197 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T07:07:43.955Z",
+    "ip": "::1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-secure",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T07:07:49.561Z",
+    "ip": "::1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-secure/compare",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T07:07:56.592Z",
+    "ip": "::1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-secure/compare",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T07:08:03.618Z",
+    "ip": "::1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-secure",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T07:08:12.518Z",
+    "ip": "::1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "sessionId": "sess_jxajug34",
+    "duration": 91,
+    "ip": "::1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T07:10:12.280Z"
+  },
+  {
+    "page": "/pricing/mylapay-secure/compare",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T07:10:28.350Z",
+    "ip": "::1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-secure",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T07:10:33.698Z",
+    "ip": "::1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T07:10:45.870Z",
+    "ip": "::1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-intellesolve",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T07:10:56.892Z",
+    "ip": "::1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-intellesolve/compare",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T07:11:13.999Z",
+    "ip": "::1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-cswitch",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T07:11:19.994Z",
+    "ip": "::1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-secure/compare",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T07:11:27.251Z",
+    "ip": "::1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/contact",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T07:12:06.322Z",
+    "ip": "::1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-cswitch/compare",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T07:12:40.175Z",
+    "ip": "::1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-intellesolve",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T07:13:18.435Z",
+    "ip": "::1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5146,5 +5146,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:36:56.572Z"
+  },
+  {
+    "page": "/",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:37:01.935Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4582,5 +4582,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:01:25.185Z"
+  },
+  {
+    "sessionId": "sess_ibinfj0g",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:01:43.891Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5374,5 +5374,53 @@
       "city": null,
       "ll": null
     }
+  },
+  {
+    "page": "/pricing/mylapay-intellesolve",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:46:31.422Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-cswitch",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:47:38.107Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-cswitch?action=trial&from=compare",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:47:44.202Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-cswitch?action=checkout&plan=basic",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:48:08.816Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4738,5 +4738,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:03:47.483Z"
+  },
+  {
+    "page": "/pricing/mylapay-secure",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:03:54.287Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4510,5 +4510,17 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:00:25.794Z"
+  },
+  {
+    "sessionId": "sess_vx4mjb8y",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:00:31.408Z"
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -5434,5 +5434,29 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:48:33.505Z"
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:48:41.747Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/products/mylapay-secure",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:48:51.869Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]

--- a/server/visitor.json
+++ b/server/visitor.json
@@ -4918,5 +4918,77 @@
       "ll": null
     },
     "timestamp": "2025-11-22T06:27:34.745Z"
+  },
+  {
+    "sessionId": "sess_9s7uw0ko",
+    "duration": 0,
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    },
+    "timestamp": "2025-11-22T06:27:41.772Z"
+  },
+  {
+    "page": "/pricing/mylapay-secure",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:27:48.138Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:28:13.996Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:28:21.160Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:30:23.344Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
+  },
+  {
+    "page": "/pricing/mylapay-tokenx",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0",
+    "timestamp": "2025-11-22T06:30:28.717Z",
+    "ip": "::ffff:127.0.0.1",
+    "location": {
+      "country": null,
+      "region": null,
+      "city": null,
+      "ll": null
+    }
   }
 ]


### PR DESCRIPTION
### Purpose

The user wanted to adjust the footer on the pricing pages to be full-width, matching the design of the homepage. They pointed out that there was unwanted padding around the footer on pages like `/pricing/mylapay-cswitch`, which was inconsistent with the homepage's full-bleed footer.

### Code changes

- **`client/components/layout/Footer.tsx`**:
    - Added a condition `isFullWidth` that checks if the current page is the homepage (`/`) or any of the pricing pages (`/pricing/*`).
    - Applied conditional CSS classes to the main `<div>` inside the `<footer>` element.
    - When `isFullWidth` is true, the `div` will have the class `w-full py-14` to make the footer span the full width of the viewport.
    - When `isFullWidth` is false, the `div` will have `max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-14`, which constrains the width and adds padding, preserving the original look on other pages.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/02ba57ec714e4b51bd04b1cb7b8bf390/orbit-world)

👀 [Preview Link](https://02ba57ec714e4b51bd04b1cb7b8bf390-orbit-world.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 7`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>02ba57ec714e4b51bd04b1cb7b8bf390</projectId>-->
<!--<branchName>orbit-world</branchName>-->